### PR TITLE
create github workflow to build release apk whenever a Release or Pre…

### DIFF
--- a/.github/workflows/release_android.yml
+++ b/.github/workflows/release_android.yml
@@ -1,0 +1,38 @@
+name: Build for Android
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    # This job will run on ubuntu virtual machine
+    runs-on: ubuntu-latest
+    steps:
+
+      # Setup Java environment in order to build the Android app.
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '12.x'
+
+      # Setup the flutter environment.
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: 'stable' # 'dev', 'alpha', default to: 'stable'
+          # flutter-version: '1.17.5' # you can also specify exact version of flutter
+
+      # Get flutter dependencies.
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build apk
+        run: flutter build apk --no-tree-shake-icons --release
+
+      # Upload generated appbundle to the artifacts.
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "build/app/outputs/flutter-apk/app-release.apk"
+          replacesArtifacts: true
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,7 +74,8 @@ android {
             // useProguard true
             minifyEnabled false
             shrinkResources false
-            signingConfig signingConfigs.release
+            //signingConfig signingConfigs.release
+            signingConfig signingConfigs.debug
         }
     }
 }


### PR DESCRIPTION
Here is a convenient github workflow that will create a release-app.apk whenever a `Release` or `Pre-Release` is created.  The android/app/build.gradle had to be modified to create a release without a keyfile. 