### PR TITLE
Fix building with flutter 3.3 in release mode (#206)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+
     <!--  NORMAL PERMISSIONS     -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -40,14 +42,35 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <receiver android:name="rekab.app.background_locator.LocatorBroadcastReceiver" android:enabled="true" android:exported="true" />
+        <!-- <receiver android:name="rekab.app.background_locator.LocatorBroadcastReceiver" android:enabled="true" android:exported="true" />
         <receiver android:name="rekab.app.background_locator.BootBroadcastReceiver" android:enabled="true" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
+        </receiver> -->
+
+        <receiver android:name="yukams.app.background_locator_2.BootBroadcastReceiver"
+            android:enabled="true" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
         </receiver>
-        <service android:name="rekab.app.background_locator.LocatorService" android:permission="android.permission.BIND_JOB_SERVICE" android:exported="true" />
-        <service android:name="rekab.app.background_locator.IsolateHolderService" android:permission="android.permission.FOREGROUND_SERVICE" android:exported="true" />
+
+        <service android:name="yukams.app.background_locator_2.IsolateHolderService"
+          android:permission="android.permission.FOREGROUND_SERVICE"
+          android:exported="true"
+          android:stopWithTask="true"
+          android:foregroundServiceType = "location"/>
+        
+        <service android:name="yukams.app.background_locator_2.LocatorService"
+          android:permission="android.permission.BIND_JOB_SERVICE"
+          android:exported="true"
+          android:stopWithTask="true"/>
+
+
+
+        <!-- <service android:name="rekab.app.background_locator.LocatorService" android:permission="android.permission.BIND_JOB_SERVICE" android:exported="true" />
+        <service android:name="rekab.app.background_locator.IsolateHolderService" android:permission="android.permission.FOREGROUND_SERVICE" android:exported="true" /> -->
         <meta-data android:name="flutterEmbedding" android:value="2" />
     </application>
 

--- a/lib/eu/hydrologis/smash/gps/gps.dart
+++ b/lib/eu/hydrologis/smash/gps/gps.dart
@@ -8,11 +8,11 @@ import 'dart:async';
 import 'dart:isolate';
 import 'dart:ui';
 
-import 'package:background_locator/background_locator.dart' as GPS;
-import 'package:background_locator/location_dto.dart';
-import 'package:background_locator/settings/android_settings.dart';
-import 'package:background_locator/settings/ios_settings.dart';
-import 'package:background_locator/settings/locator_settings.dart';
+import 'package:background_locator_2/background_locator.dart' as GPS;
+import 'package:background_locator_2/location_dto.dart';
+import 'package:background_locator_2/settings/android_settings.dart';
+import 'package:background_locator_2/settings/ios_settings.dart';
+import 'package:background_locator_2/settings/locator_settings.dart';
 import 'package:dart_hydrologis_utils/dart_hydrologis_utils.dart';
 import 'package:geodesy/geodesy.dart' as GEOD;
 import 'package:latlong2/latlong.dart';
@@ -142,6 +142,7 @@ class GpsHandler with Localization {
 
   GpsHandler._internal();
 
+  @pragma('vm:entry-point')
   static void callback(LocationDto locationDto) async {
     final SendPort? send = IsolateNameServer.lookupPortByName(_isolateName);
     send?.send(locationDto);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'generated/l10n.dart';
 const DOCATCHER = false;
 
 void main() {
+  // WidgetsFlutterBinding.ensureInitialized();
   // TODO endable catcher again once it is aligned with libs
   // if (DOCATCHER) {
   //   CatcherOptions debugOptions =

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -54,9 +54,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "10b10556223cbd477372f9ca2db8d39bbb44f0d1"
-      resolved-ref: "10b10556223cbd477372f9ca2db8d39bbb44f0d1"
-      url: "https://github.com/Yukams/background_locator_fixed.git"
+      ref: "fix/callback-in-release-build"
+      resolved-ref: "3e0e4dcad802b5122d480c940e391c4b518a4f45"
+      url: "https://github.com/sanak/background_locator_2.git"
     source: git
     version: "2.0.6"
   badges:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,15 +50,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
-  background_locator:
+  background_locator_2:
     dependency: "direct main"
     description:
       path: "."
-      ref: "830989e338b2d7b789dc2ffa2bd407e7a1d92b19"
-      resolved-ref: "830989e338b2d7b789dc2ffa2bd407e7a1d92b19"
-      url: "https://github.com/caiobraga/background_locator.git"
+      ref: "10b10556223cbd477372f9ca2db8d39bbb44f0d1"
+      resolved-ref: "10b10556223cbd477372f9ca2db8d39bbb44f0d1"
+      url: "https://github.com/Yukams/background_locator_fixed.git"
     source: git
-    version: "1.6.12"
+    version: "2.0.6"
   badges:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -165,13 +165,18 @@ dependencies:
   #    <key>UIFileSharingEnabled</key>
   #    <true/>
   # GPL 3.0
-  background_locator: #1.6.12
+  # background_locator: #1.6.12
     # git:
     #   url: https://github.com/moovida/background_locator.git
     #   ref: gms_free_1.6.12_version
+    # git:
+    #   url: https://github.com/caiobraga/background_locator.git
+    #   ref: 830989e338b2d7b789dc2ffa2bd407e7a1d92b19
+  background_locator_2:
     git:
-      url: https://github.com/caiobraga/background_locator.git
-      ref: 830989e338b2d7b789dc2ffa2bd407e7a1d92b19
+      url: https://github.com/Yukams/background_locator_fixed.git
+      ref: 10b10556223cbd477372f9ca2db8d39bbb44f0d1
+
       
   # MIT
   # geolocator: ^5.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -173,9 +173,10 @@ dependencies:
     #   url: https://github.com/caiobraga/background_locator.git
     #   ref: 830989e338b2d7b789dc2ffa2bd407e7a1d92b19
   background_locator_2:
+    # path: ../background_locator_2/
     git:
-      url: https://github.com/Yukams/background_locator_fixed.git
-      ref: 10b10556223cbd477372f9ca2db8d39bbb44f0d1
+      url: https://github.com/sanak/background_locator_2.git
+      ref: fix/callback-in-release-build
 
       
   # MIT


### PR DESCRIPTION
@moovida  
Related with https://github.com/geopaparazzi/smash/issues/206#issuecomment-1328893349, I created this PR branch from   upstream `gps_issues_fix` branch with rebasing from the latest `master` branch.

On my macOS + Android Pixel5a (Android 13), I couldn't reproduce GPS turned off issue with the following steps, so could you check this changes on your environment ?
Steps:
1. Modify `android/app/build.gradle` for release build without signing key.
    ```diff
    --- a/android/app/build.gradle
    +++ b/android/app/build.gradle
    @@ -74,8 +74,8 @@ android {
                 // useProguard true
                 minifyEnabled false
                 shrinkResources false
    -            signingConfig signingConfigs.release
    -            // signingConfig signingConfigs.debug
    +//            signingConfig signingConfigs.release
    +            signingConfig signingConfigs.debug
             }
         }
     }
    ```
2. Run app with release mode
   ```sh
   flutter clean
   flutter pub get
   flutter run --release
   ```