### PR TITLE
upgrade some packages, use namespace for badge package

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '14.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,18 +1,16 @@
 PODS:
-  - background_locator (0.0.1):
-    - Flutter
-  - catcher (0.0.1):
+  - background_locator_2 (0.0.1):
     - Flutter
   - device_info_plus (0.0.1):
     - Flutter
-  - DKImagePickerController/Core (4.3.2):
+  - DKImagePickerController/Core (4.3.4):
     - DKImagePickerController/ImageDataManager
     - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.2)
-  - DKImagePickerController/PhotoGallery (4.3.2):
+  - DKImagePickerController/ImageDataManager (4.3.4)
+  - DKImagePickerController/PhotoGallery (4.3.4):
     - DKImagePickerController/Core
     - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.2)
+  - DKImagePickerController/Resource (4.3.4)
   - DKPhotoGallery (0.0.17):
     - DKPhotoGallery/Core (= 0.0.17)
     - DKPhotoGallery/Model (= 0.0.17)
@@ -40,75 +38,65 @@ PODS:
     - DKImagePickerController/PhotoGallery
     - Flutter
   - Flutter (1.0.0)
-  - flutter_mailer (0.0.1):
-    - Flutter
   - flutter_ringtone_player (0.0.1):
     - Flutter
   - flutter_screen_wake (0.0.1):
     - Flutter
-  - fluttertoast (0.0.2):
+  - geocoding (1.0.5):
     - Flutter
-    - Toast
-  - image_picker (0.0.1):
-    - Flutter
-  - package_info (0.0.1):
+  - image_picker_ios (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_ex (0.0.1):
     - Flutter
-  - path_provider_ios (0.0.1):
+  - path_provider_foundation (0.0.1):
     - Flutter
-  - "permission_handler (5.1.0+2)":
+    - FlutterMacOS
+  - permission_handler_apple (9.0.4):
     - Flutter
-  - SDWebImage (5.12.5):
-    - SDWebImage/Core (= 5.12.5)
-  - SDWebImage/Core (5.12.5)
+  - SDWebImage (5.15.5):
+    - SDWebImage/Core (= 5.15.5)
+  - SDWebImage/Core (5.15.5)
   - share_extend (0.0.1):
     - Flutter
-  - shared_preferences_ios (0.0.1):
+  - shared_preferences_foundation (0.0.1):
     - Flutter
-  - sqlite3 (3.38.1):
-    - sqlite3/common (= 3.38.1)
-  - sqlite3/common (3.38.1)
-  - sqlite3/fts5 (3.38.1):
+    - FlutterMacOS
+  - sqlite3 (3.41.0):
+    - sqlite3/common (= 3.41.0)
+  - sqlite3/common (3.41.0)
+  - sqlite3/fts5 (3.41.0):
     - sqlite3/common
-  - sqlite3/json1 (3.38.1):
+  - sqlite3/perf-threadsafe (3.41.0):
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.38.1):
-    - sqlite3/common
-  - sqlite3/rtree (3.38.1):
+  - sqlite3/rtree (3.41.0):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
-    - sqlite3 (~> 3.38.0)
+    - sqlite3 (~> 3.41.0)
     - sqlite3/fts5
-    - sqlite3/json1
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
-  - SwiftyGif (5.4.3)
-  - Toast (4.0.0)
+  - SwiftyGif (5.4.4)
   - url_launcher_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
-  - background_locator (from `.symlinks/plugins/background_locator/ios`)
-  - catcher (from `.symlinks/plugins/catcher/ios`)
+  - background_locator_2 (from `.symlinks/plugins/background_locator_2/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
-  - flutter_mailer (from `.symlinks/plugins/flutter_mailer/ios`)
   - flutter_ringtone_player (from `.symlinks/plugins/flutter_ringtone_player/ios`)
   - flutter_screen_wake (from `.symlinks/plugins/flutter_screen_wake/ios`)
-  - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
-  - image_picker (from `.symlinks/plugins/image_picker/ios`)
-  - package_info (from `.symlinks/plugins/package_info/ios`)
+  - geocoding (from `.symlinks/plugins/geocoding/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ex (from `.symlinks/plugins/path_provider_ex/ios`)
-  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
-  - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - share_extend (from `.symlinks/plugins/share_extend/ios`)
-  - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -119,75 +107,64 @@ SPEC REPOS:
     - SDWebImage
     - sqlite3
     - SwiftyGif
-    - Toast
 
 EXTERNAL SOURCES:
-  background_locator:
-    :path: ".symlinks/plugins/background_locator/ios"
-  catcher:
-    :path: ".symlinks/plugins/catcher/ios"
+  background_locator_2:
+    :path: ".symlinks/plugins/background_locator_2/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   file_picker:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
-  flutter_mailer:
-    :path: ".symlinks/plugins/flutter_mailer/ios"
   flutter_ringtone_player:
     :path: ".symlinks/plugins/flutter_ringtone_player/ios"
   flutter_screen_wake:
     :path: ".symlinks/plugins/flutter_screen_wake/ios"
-  fluttertoast:
-    :path: ".symlinks/plugins/fluttertoast/ios"
-  image_picker:
-    :path: ".symlinks/plugins/image_picker/ios"
-  package_info:
-    :path: ".symlinks/plugins/package_info/ios"
+  geocoding:
+    :path: ".symlinks/plugins/geocoding/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_ex:
     :path: ".symlinks/plugins/path_provider_ex/ios"
-  path_provider_ios:
-    :path: ".symlinks/plugins/path_provider_ios/ios"
-  permission_handler:
-    :path: ".symlinks/plugins/permission_handler/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/ios"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
   share_extend:
     :path: ".symlinks/plugins/share_extend/ios"
-  shared_preferences_ios:
-    :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
   sqlite3_flutter_libs:
     :path: ".symlinks/plugins/sqlite3_flutter_libs/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  background_locator: d8daad218f2282920654de8a649b430d75c218d9
-  catcher: 67a006a3c121c4bbf1202d1e5ea186afb7ef4a18
+  background_locator_2: bc8a422343ab656d5bd98e08694c6f89fef20418
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  DKImagePickerController: b5eb7f7a388e4643264105d648d01f727110fc3d
+  DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
-  file_picker: 3e6c3790de664ccf9b882732d9db5eaf6b8d4eb1
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  flutter_mailer: 2ef5a67087bc8c6c4cefd04a178bf1ae2c94cd83
+  file_picker: ce3938a0df3cc1ef404671531facef740d03f920
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_ringtone_player: 15eba85187230b87b2512f0e1b92225618bc03e7
   flutter_screen_wake: 4d3c2b43943ea81bd5e591fd4e639ea537f4ca5e
-  fluttertoast: 16fbe6039d06a763f3533670197d01fc73459037
-  image_picker: 541dcbb3b9cf32d87eacbd957845d8651d6c62c3
-  package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
+  geocoding: 32cfcdb16d38d907caaba65e2e42ad10d38bee58
+  image_picker_ios: 58b9c4269cb176f89acea5e5d043c9358f2d25f8
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ex: 95397ca0c3f5f99c8538aec3736674fa9cefc1b6
-  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
-  permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
-  SDWebImage: 0905f1b7760fc8ac4198cae0036600d67478751e
+  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
+  permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
+  SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
   share_extend: b6748dc53695587891126a89533b862b92548c7b
-  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
-  sqlite3: cd8b3380fcf65663ed84d17aab294db7626a314e
-  sqlite3_flutter_libs: 14a93fdcff62c6a346356df0b8e1b3f35fbab8f2
-  SwiftyGif: 6c3eafd0ce693cad58bb63d2b2fb9bacb8552780
-  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
-  url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
+  shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
+  sqlite3: d31b2b69d59bd1b4ab30e5c92eb18fd8e82fa392
+  sqlite3_flutter_libs: 78f93cb854d4680595bc2c63c57209a104b2efb1
+  SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
-PODFILE CHECKSUM: a347fd0ae05b3d8478a3efc87a129c3eb6e544ea
+PODFILE CHECKSUM: 925e2dddb87ce5d196678c3774b20c625ed422d8
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -238,6 +238,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -252,6 +253,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -275,22 +277,18 @@
 				"${BUILT_PRODUCTS_DIR}/DKPhotoGallery/DKPhotoGallery.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyGif/SwiftyGif.framework",
-				"${BUILT_PRODUCTS_DIR}/Toast/Toast.framework",
-				"${BUILT_PRODUCTS_DIR}/background_locator/background_locator.framework",
-				"${BUILT_PRODUCTS_DIR}/catcher/catcher.framework",
+				"${BUILT_PRODUCTS_DIR}/background_locator_2/background_locator_2.framework",
 				"${BUILT_PRODUCTS_DIR}/device_info_plus/device_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/file_picker/file_picker.framework",
-				"${BUILT_PRODUCTS_DIR}/flutter_mailer/flutter_mailer.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_ringtone_player/flutter_ringtone_player.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_screen_wake/flutter_screen_wake.framework",
-				"${BUILT_PRODUCTS_DIR}/fluttertoast/fluttertoast.framework",
-				"${BUILT_PRODUCTS_DIR}/image_picker/image_picker.framework",
-				"${BUILT_PRODUCTS_DIR}/package_info/package_info.framework",
+				"${BUILT_PRODUCTS_DIR}/geocoding/geocoding.framework",
+				"${BUILT_PRODUCTS_DIR}/image_picker_ios/image_picker_ios.framework",
 				"${BUILT_PRODUCTS_DIR}/package_info_plus/package_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider_ex/path_provider_ex.framework",
-				"${BUILT_PRODUCTS_DIR}/path_provider_ios/path_provider_ios.framework",
+				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
 				"${BUILT_PRODUCTS_DIR}/share_extend/share_extend.framework",
-				"${BUILT_PRODUCTS_DIR}/shared_preferences_ios/shared_preferences_ios.framework",
+				"${BUILT_PRODUCTS_DIR}/shared_preferences_foundation/shared_preferences_foundation.framework",
 				"${BUILT_PRODUCTS_DIR}/sqlite3/sqlite3.framework",
 				"${BUILT_PRODUCTS_DIR}/sqlite3_flutter_libs/sqlite3_flutter_libs.framework",
 				"${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios.framework",
@@ -301,22 +299,18 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DKPhotoGallery.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyGif.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toast.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/background_locator.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/catcher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/background_locator_2.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/file_picker.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_mailer.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_ringtone_player.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_screen_wake.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/fluttertoast.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/image_picker.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/geocoding.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/image_picker_ios.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_ex.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_ios.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share_extend.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_ios.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_foundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqlite3.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqlite3_flutter_libs.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios.framework",
@@ -401,7 +395,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -424,7 +418,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -490,7 +484,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -539,7 +533,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -565,7 +559,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -602,7 +596,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Flutter
-import background_locator
+import background_locator_2
 
 func registerPlugins(registry: FlutterPluginRegistry) -> () {
     GeneratedPluginRegistrant.register(with: registry)

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -76,5 +76,9 @@
 		</array>
 		<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false />
-	</dict>
+		<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+</dict>
 </plist>

--- a/lib/eu/hydrologis/smash/mainview_utils.dart
+++ b/lib/eu/hydrologis/smash/mainview_utils.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:badges/badges.dart';
+import 'package:badges/badges.dart' as badges;
 import 'package:dart_hydrologis_utils/dart_hydrologis_utils.dart' as HU;
 import 'package:dart_jts/dart_jts.dart';
 import 'package:flutter/material.dart';
@@ -36,18 +36,22 @@ class DashboardUtils {
   static Widget makeToolbarBadge(Widget widget, int badgeValue,
       {Color? textColor,
       Color? badgeColor,
-      BadgePosition? badgePosition,
+      badges.BadgePosition? badgePosition,
       double? iconSize}) {
     if (badgeValue > 0) {
-      return Badge(
-        badgeColor: badgeColor != null ? badgeColor : SmashColors.mainSelection,
-        shape: badgeValue > 999 ? BadgeShape.square : BadgeShape.circle,
-        borderRadius: BorderRadius.circular(20.0),
-        toAnimate: false,
+      return badges.Badge(
+        badgeStyle: badges.BadgeStyle(
+          badgeColor: badgeColor != null ? badgeColor : SmashColors.mainSelection,
+          shape: badgeValue > 999 ? badges.BadgeShape.square : badges.BadgeShape.circle,
+          borderRadius: BorderRadius.circular(20.0),
+        ),
+        badgeAnimation: badges.BadgeAnimation.slide(
+          toAnimate: false,
+        ),
         position: badgePosition != null
             ? badgePosition
             : iconSize != null
-                ? BadgePosition.topStart(
+                ? badges.BadgePosition.topStart(
                     top: -iconSize / 2, start: 0.1 * iconSize)
                 : null,
         badgeContent: Text(
@@ -64,13 +68,17 @@ class DashboardUtils {
   static Widget makeToolbarZoomBadge(Widget widget, int badgeValue,
       {double? iconSize}) {
     if (badgeValue > 0) {
-      return Badge(
-        badgeColor: SmashColors.mainDecorations,
-        shape: BadgeShape.circle,
+      return badges.Badge(
+        badgeStyle: badges.BadgeStyle(
+          badgeColor: SmashColors.mainDecorations,
+          shape: badges.BadgeShape.circle,
+        ),
         position: iconSize != null
-            ? BadgePosition.topEnd(top: -iconSize / 2, end: -iconSize / 3)
+            ? badges.BadgePosition.topEnd(top: -iconSize / 2, end: -iconSize / 3)
             : null,
-        toAnimate: false,
+        badgeAnimation: badges.BadgeAnimation.slide(
+          toAnimate: false,
+        ),
         badgeContent: Text(
           '$badgeValue',
           style: TextStyle(color: Colors.white),

--- a/lib/eu/hydrologis/smash/widgets/toolbar_tools.dart
+++ b/lib/eu/hydrologis/smash/widgets/toolbar_tools.dart
@@ -3,7 +3,7 @@
  * Use of this source code is governed by a GPL3 license that can be
  * found in the LICENSE file.
  */
-import 'package:badges/badges.dart';
+import 'package:badges/badges.dart' as badges;
 import 'package:dart_hydrologis_db/dart_hydrologis_db.dart';
 import 'package:dart_hydrologis_utils/dart_hydrologis_utils.dart'
     hide TextStyle;
@@ -461,12 +461,16 @@ class RulerButton extends StatelessWidget {
         ),
       );
       if (rulerState.lengthMeters != null && rulerState.lengthMeters != 0) {
-        w = Badge(
-          badgeColor: SmashColors.mainSelection,
-          shape: BadgeShape.square,
-          borderRadius: BorderRadius.circular(10.0),
-          toAnimate: false,
-          position: BadgePosition.topStart(
+        w = badges.Badge(
+          badgeStyle: badges.BadgeStyle(
+            badgeColor: SmashColors.mainSelection,
+            shape: badges.BadgeShape.square,
+            borderRadius: BorderRadius.circular(10.0),
+          ),
+          badgeAnimation: badges.BadgeAnimation.slide(
+            toAnimate: false,
+          ),
+          position: badges.BadgePosition.topStart(
               top: -_iconSize / 2, start: 0.1 * _iconSize),
           badgeContent: Text(
             StringUtilities.formatMeters(rulerState.lengthMeters!),

--- a/lib/generated/l10n_nb.dart
+++ b/lib/generated/l10n_nb.dart
@@ -5,148 +5,148 @@ class SLNb extends SL {
   SLNb([String locale = 'nb']) : super(locale);
 
   @override
-  String get main_welcome => 'Welcome to SMASH!';
+  String get main_welcome => 'Velkommen til SMASH.';
 
   @override
-  String get main_check_location_permission => 'Checking location permission…';
+  String get main_check_location_permission => 'Sjekker posisjonstilgang …';
 
   @override
-  String get main_location_permission_granted => 'Location permission granted.';
+  String get main_location_permission_granted => 'Posisjonstilgang innvilget.';
 
   @override
-  String get main_checkingStoragePermission => 'Checking storage permission…';
+  String get main_checkingStoragePermission => 'Sjekker lagringstilgang …';
 
   @override
-  String get main_storagePermissionGranted => 'Storage permission granted.';
+  String get main_storagePermissionGranted => 'Lagringstilgang innvilget.';
 
   @override
-  String get main_loadingPreferences => 'Loading preferences…';
+  String get main_loadingPreferences => 'Laster inn innstillinger …';
 
   @override
-  String get main_preferencesLoaded => 'Preferences loaded.';
+  String get main_preferencesLoaded => 'Innstillinger innlastet.';
 
   @override
-  String get main_loadingWorkspace => 'Loading workspace…';
+  String get main_loadingWorkspace => 'Laster inn arbeidsområde.';
 
   @override
-  String get main_workspaceLoaded => 'Workspace loaded.';
+  String get main_workspaceLoaded => 'Arbeidsområde innlastet.';
 
   @override
-  String get main_loadingTagsList => 'Loading tags list…';
+  String get main_loadingTagsList => 'Laster inn etikettliste …';
 
   @override
-  String get main_tagsListLoaded => 'Tags list loaded.';
+  String get main_tagsListLoaded => 'Etikettliste innlastet.';
 
   @override
-  String get main_loadingKnownProjections => 'Loading known projections…';
+  String get main_loadingKnownProjections => 'Laster inn kjente projeksjoner …';
 
   @override
-  String get main_knownProjectionsLoaded => 'Known projections loaded.';
+  String get main_knownProjectionsLoaded => 'Kjente projeksjoner innlastet.';
 
   @override
-  String get main_loadingFences => 'Loading fences…';
+  String get main_loadingFences => 'Laster inn gjerder …';
 
   @override
-  String get main_fencesLoaded => 'Fences loaded.';
+  String get main_fencesLoaded => 'Gjerder innlastet.';
 
   @override
-  String get main_loadingLayersList => 'Loading layers list…';
+  String get main_loadingLayersList => 'Laster inn lagliste …';
 
   @override
-  String get main_layersListLoaded => 'Layers list loaded.';
+  String get main_layersListLoaded => 'Lagliste innlastet.';
 
   @override
-  String get main_locationBackgroundWarning => 'Grant location permission in the next step to allow GPS logging in the background. (Otherwise it only works in the foreground.)\nNo data is shared, and only saved locally on the device.';
+  String get main_locationBackgroundWarning => 'Innvilg posisjonstilgang i neste steg for å tillate GPS-logging i bakgrunnen. (Ellers virker det kun i forgrunnen.)\nIngen data deles, og lagres kun lokalt på enheten.';
 
   @override
-  String get main_StorageIsInternalWarning => 'Please read carefully!\nOn Android 11 and above, the SMASH project folder must be placed in the\n\nAndroid/data/eu.hydrologis.smash/files/smash\n\nfolder in your storage to be used.\nIf the app is uninstalled, the system removes it, so back up your data if you do.\n\nA better solution is in the works.';
+  String get main_StorageIsInternalWarning => 'Les dette nøye.\nPå Android 11 og videre må SMASH-prosjektmappen lagres i\n\nAndroid/data/eu.hydrologis.smash/files/smash\n\n-mappen i lagringen din for å brukes. Hvis programmet avinstalleres vil systemet fjerne denne.\nHvis dette er tilfelle må du sikkerhetskopiere dataen din først.\n\nEn bedre løsning er underveis.';
 
   @override
-  String get main_locationPermissionIsMandatoryToOpenSmash => 'Location permission is mandatory to open SMASH.';
+  String get main_locationPermissionIsMandatoryToOpenSmash => 'Posisjonstilgang kreves for å åpne SMASH.';
 
   @override
-  String get main_storagePermissionIsMandatoryToOpenSmash => 'Storage permission is mandatory to open SMASH.';
+  String get main_storagePermissionIsMandatoryToOpenSmash => 'Lagringstilgang kreves for å åpne SMASH.';
 
   @override
-  String get main_anErrorOccurredTapToView => 'An error occurred. Tap to view.';
+  String get main_anErrorOccurredTapToView => 'Noe gikk galt. Trykk for å vise.';
 
   @override
-  String get mainView_loadingData => 'Loading data…';
+  String get mainView_loadingData => 'Laster inn data …';
 
   @override
-  String get mainView_turnGpsOn => 'Turn GPS on';
+  String get mainView_turnGpsOn => 'Skru på GPS';
 
   @override
-  String get mainView_turnGpsOff => 'Turn GPS off';
+  String get mainView_turnGpsOff => 'Skru av GPS';
 
   @override
-  String get mainView_exit => 'Exit';
+  String get mainView_exit => 'Avslutt';
 
   @override
-  String get mainView_areYouSureCloseTheProject => 'Close the project?';
+  String get mainView_areYouSureCloseTheProject => 'Lukk prosjektet?';
 
   @override
-  String get mainView_activeOperationsWillBeStopped => 'Active operations will be stopped.';
+  String get mainView_activeOperationsWillBeStopped => 'Aktive operasjoner vil bli stoppet';
 
   @override
-  String get mainView_showInteractiveCoachMarks => 'Show interactive coach marks.';
+  String get mainView_showInteractiveCoachMarks => 'Vis interaktive veiledningsmerker.';
 
   @override
-  String get mainView_openToolsDrawer => 'Open tools drawer.';
+  String get mainView_openToolsDrawer => 'Åpne verktøysskuff.';
 
   @override
-  String get mainView_zoomIn => 'Zoom in';
+  String get mainView_zoomIn => 'Forstørr';
 
   @override
-  String get mainView_zoomOut => 'Zoom out';
+  String get mainView_zoomOut => 'Forminsk';
 
   @override
-  String get mainView_formNotes => 'Form Notes';
+  String get mainView_formNotes => 'Skjemanotater';
 
   @override
-  String get mainView_simpleNotes => 'Simple Notes';
+  String get mainView_simpleNotes => 'Enkle notater';
 
   @override
-  String get mainviewUtils_projects => 'Projects';
+  String get mainviewUtils_projects => 'Prosjekter';
 
   @override
-  String get mainviewUtils_import => 'Import';
+  String get mainviewUtils_import => 'Importer';
 
   @override
-  String get mainviewUtils_export => 'Export';
+  String get mainviewUtils_export => 'Eksporter';
 
   @override
-  String get mainviewUtils_settings => 'Settings';
+  String get mainviewUtils_settings => 'Innstillinger';
 
   @override
-  String get mainviewUtils_onlineHelp => 'Online Help';
+  String get mainviewUtils_onlineHelp => 'Nettbasert hjelp';
 
   @override
-  String get mainviewUtils_about => 'About';
+  String get mainviewUtils_about => 'Om';
 
   @override
-  String get mainviewUtils_projectInfo => 'Project Info';
+  String get mainviewUtils_projectInfo => 'Prosjektinfo';
 
   @override
-  String get mainviewUtils_project => 'Project';
+  String get mainviewUtils_project => 'Prosjekt';
 
   @override
   String get mainviewUtils_database => 'Database';
 
   @override
-  String get mainviewUtils_extras => 'Extras';
+  String get mainviewUtils_extras => 'Ekstra';
 
   @override
-  String get mainviewUtils_availableIcons => 'Available icons';
+  String get mainviewUtils_availableIcons => 'Tilgjengelige ikoner';
 
   @override
-  String get mainviewUtils_offlineMaps => 'Offline maps';
+  String get mainviewUtils_offlineMaps => 'Frakoblede kart';
 
   @override
-  String get mainviewUtils_positionTools => 'Position Tools';
+  String get mainviewUtils_positionTools => 'Posisjoneringsverktøy';
 
   @override
-  String get mainviewUtils_goTo => 'Go to';
+  String get mainviewUtils_goTo => 'Gå til';
 
   @override
   String get mainviewUtils_goToCoordinate => 'Go to coordinate';
@@ -161,1336 +161,1336 @@ class SLNb extends SL {
   String get mainviewUtils_goToCoordinateEmpty => 'This can\'t be empty.';
 
   @override
-  String get mainviewUtils_sharePosition => 'Share position';
+  String get mainviewUtils_sharePosition => 'Del posisjon';
 
   @override
-  String get mainviewUtils_rotateMapWithGps => 'Rotate map with GPS';
+  String get mainviewUtils_rotateMapWithGps => 'Roter kartet med GPS';
 
   @override
-  String get exportWidget_export => 'Export';
+  String get exportWidget_export => 'Eksporter';
 
   @override
-  String get exportWidget_pdfExported => 'PDF exported';
+  String get exportWidget_pdfExported => 'PDF eksportert';
 
   @override
-  String get exportWidget_exportToPortableDocumentFormat => 'Export project to Portable Document Format';
+  String get exportWidget_exportToPortableDocumentFormat => 'Eksporter prosjekt til PDF';
 
   @override
-  String get exportWidget_gpxExported => 'GPX exported';
+  String get exportWidget_gpxExported => 'GPX eksportert';
 
   @override
-  String get exportWidget_exportToGpx => 'Export project to GPX';
+  String get exportWidget_exportToGpx => 'Eksporter prosjekt til GPX';
 
   @override
-  String get exportWidget_kmlExported => 'KML exported';
+  String get exportWidget_kmlExported => 'KML eksportert';
 
   @override
-  String get exportWidget_exportToKml => 'Export project to KML';
+  String get exportWidget_exportToKml => 'Eksporter prosjekt til KML';
 
   @override
-  String get exportWidget_imagesToFolderExported => 'Images exported';
+  String get exportWidget_imagesToFolderExported => 'Bilder eksportert';
 
   @override
-  String get exportWidget_exportImagesToFolder => 'Export project images to folder';
+  String get exportWidget_exportImagesToFolder => 'Eksporter prosjektbilder til mappe';
 
   @override
-  String get exportWidget_exportImagesToFolderTitle => 'Images';
+  String get exportWidget_exportImagesToFolderTitle => 'Bilder';
 
   @override
-  String get exportWidget_geopackageExported => 'Geopackage exported';
+  String get exportWidget_geopackageExported => 'Geopakke eksportert';
 
   @override
-  String get exportWidget_exportToGeopackage => 'Export project to Geopackage';
+  String get exportWidget_exportToGeopackage => 'Eksporter prosjekt til Geopakke';
 
   @override
-  String get exportWidget_exportToGSS => 'Export to Geopaparazzi Survey Server';
+  String get exportWidget_exportToGSS => 'Eksporter til Geopaparazzi-undersøkelsestjener';
 
   @override
-  String get gssExport_gssExport => 'GSS Export';
+  String get gssExport_gssExport => 'GSS-eksport';
 
   @override
-  String get gssExport_setProjectDirty => 'Set project to DIRTY?';
+  String get gssExport_setProjectDirty => 'Sett prosjekt som skittent?';
 
   @override
-  String get gssExport_thisCantBeUndone => 'This can\'t be undone!';
+  String get gssExport_thisCantBeUndone => 'Dette kan ikke angres.';
 
   @override
-  String get gssExport_restoreProjectAsDirty => 'Restore project as all dirty.';
+  String get gssExport_restoreProjectAsDirty => 'Gjenopprett prosjekt der alt er skittent?';
 
   @override
-  String get gssExport_setProjectClean => 'Set project to CLEAN?';
+  String get gssExport_setProjectClean => 'Sett prosjekt som rent?';
 
   @override
-  String get gssExport_restoreProjectAsClean => 'Restore project as all clean.';
+  String get gssExport_restoreProjectAsClean => 'Gjenopprett prosjekt der alt er rent?';
 
   @override
-  String get gssExport_nothingToSync => 'Nothing to sync.';
+  String get gssExport_nothingToSync => 'Ingenting å synkronisere.';
 
   @override
-  String get gssExport_collectingSyncStats => 'Collecting sync stats…';
+  String get gssExport_collectingSyncStats => 'Samler inn synkroniseringsstatistikk …';
 
   @override
-  String get gssExport_unableToSyncDueToError => 'Unable to sync due to an error, check diagnostics.';
+  String get gssExport_unableToSyncDueToError => 'Kunne ikke synkronisere som følge av feil. Sjekk diagnostikk.';
 
   @override
-  String get gssExport_noGssUrlSet => 'No GSS server URL has been set. Check your settings.';
+  String get gssExport_noGssUrlSet => 'Ingen GSS-tjenernettadresse har blitt satt. Sjekk innstillingene dine.';
 
   @override
-  String get gssExport_noGssPasswordSet => 'No GSS server password has been set. Check your settings.';
+  String get gssExport_noGssPasswordSet => 'Inget GSS-tjenerpasssord har blitt satt. Sjekk innstillingene dine.';
 
   @override
-  String get gssExport_synStats => 'Sync Stats';
+  String get gssExport_synStats => 'Synkroniser statistikk';
 
   @override
-  String get gssExport_followingDataWillBeUploaded => 'The following data will be uploaded upon sync.';
+  String get gssExport_followingDataWillBeUploaded => 'Følgende data vil bli opplastet ved synkronisering.';
 
   @override
-  String get gssExport_gpsLogs => 'GPS Logs:';
+  String get gssExport_gpsLogs => 'GPS-logger:';
 
   @override
-  String get gssExport_simpleNotes => 'Simple Notes:';
+  String get gssExport_simpleNotes => 'Enkle notater:';
 
   @override
-  String get gssExport_formNotes => 'Form Notes:';
+  String get gssExport_formNotes => 'Skjemanotater:';
 
   @override
-  String get gssExport_images => 'Images:';
+  String get gssExport_images => 'Bilder:';
 
   @override
-  String get gssExport_shouldNotHappen => 'Should not happen';
+  String get gssExport_shouldNotHappen => 'Skal ikke skje';
 
   @override
-  String get gssExport_upload => 'Upload';
+  String get gssExport_upload => 'Last opp';
 
   @override
-  String get geocoding_geocoding => 'Geocoding';
+  String get geocoding_geocoding => 'Geokoding';
 
   @override
-  String get geocoding_nothingToLookFor => 'Nothing to look for. Insert an address.';
+  String get geocoding_nothingToLookFor => 'Ingenting å se etter. Sett inn en adresse.';
 
   @override
-  String get geocoding_launchGeocoding => 'Launch Geocoding';
+  String get geocoding_launchGeocoding => 'Start geokoding';
 
   @override
-  String get geocoding_searching => 'Searching…';
+  String get geocoding_searching => 'Søker …';
 
   @override
-  String get gps_smashIsActive => 'SMASH is active';
+  String get gps_smashIsActive => 'SMASH er aktivt';
 
   @override
-  String get gps_smashIsLogging => 'SMASH is logging';
+  String get gps_smashIsLogging => 'SMASH logger';
 
   @override
-  String get gps_locationTracking => 'Location tracking';
+  String get gps_locationTracking => 'Posisjonssporing';
 
   @override
-  String get gps_smashLocServiceIsActive => 'SMASH location service is active.';
+  String get gps_smashLocServiceIsActive => 'SMASH-posisjonstjenesten er aktiv.';
 
   @override
-  String get gps_backgroundLocIsOnToKeepRegistering => 'Background location is on to keep the app registering the location even when the app is in background.';
+  String get gps_backgroundLocIsOnToKeepRegistering => 'Bakgrunnsposisjon er på for at programme skal kunne registrere posisjon selv i bakgrunnen.';
 
   @override
-  String get gssImport_gssImport => 'GSS Import';
+  String get gssImport_gssImport => 'GSS-import';
 
   @override
-  String get gssImport_downloadingDataList => 'Downloading data list…';
+  String get gssImport_downloadingDataList => 'Laster ned dataliste …';
 
   @override
-  String get gssImport_unableDownloadDataList => 'Unable to download data list due to an error. Check your settings and the log.';
+  String get gssImport_unableDownloadDataList => 'Kunne ikke laste ned data. Sjekk innstillingene dine og loggen.';
 
   @override
-  String get gssImport_noGssUrlSet => 'No GSS server URL has been set. Check your settings.';
+  String get gssImport_noGssUrlSet => 'Ingen GSS-tjenernettadresse har blitt satt. Sjekk innstillingene dine.';
 
   @override
-  String get gssImport_noGssPasswordSet => 'No GSS server password has been set. Check your settings.';
+  String get gssImport_noGssPasswordSet => 'Inget GSS-tjenerpassord har blitt satt. Sjekk innstillingene dine.';
 
   @override
-  String get gssImport_noPermToAccessServer => 'No permission to access the server. Check your credentials.';
+  String get gssImport_noPermToAccessServer => 'Ingen tilgang til tjeneren. Sjekk identitetsdetaljene dine.';
 
   @override
   String get gssImport_data => 'Data';
 
   @override
-  String get gssImport_dataSetsDownloadedMapsFolder => 'Datasets are downloaded into the maps folder.';
+  String get gssImport_dataSetsDownloadedMapsFolder => 'Datasett lastes ned til kartmappen.';
 
   @override
-  String get gssImport_noDataAvailable => 'No data available.';
+  String get gssImport_noDataAvailable => 'Ingen tilgjengelig data.';
 
   @override
-  String get gssImport_projects => 'Projects';
+  String get gssImport_projects => 'Prosjekter';
 
   @override
-  String get gssImport_projectsDownloadedProjectFolder => 'Projects are downloaded into the projects folder.';
+  String get gssImport_projectsDownloadedProjectFolder => 'Prosjekter lastes ned til prosjektmappen.';
 
   @override
-  String get gssImport_noProjectsAvailable => 'No projects available.';
+  String get gssImport_noProjectsAvailable => 'Ingen tilgjengelige prosjekter.';
 
   @override
-  String get gssImport_forms => 'Forms';
+  String get gssImport_forms => 'Skjemaer';
 
   @override
-  String get gssImport_tagsDownloadedFormsFolder => 'Tags files are downloaded into the forms folder.';
+  String get gssImport_tagsDownloadedFormsFolder => 'Etiketter lastes ned til skjemamappen.';
 
   @override
-  String get gssImport_noTagsAvailable => 'No tags available.';
+  String get gssImport_noTagsAvailable => 'Ingen tilgjengelige etiketter.';
 
   @override
-  String get importWidget_import => 'Import';
+  String get importWidget_import => 'Importer';
 
   @override
-  String get importWidget_importFromGeopaparazzi => 'Import from Geopaparazzi Survey Server';
+  String get importWidget_importFromGeopaparazzi => 'Importer fra Geopaparazzi-undersøkelsestjener';
 
   @override
-  String get layersView_layerList => 'Layer List';
+  String get layersView_layerList => 'Lagliste';
 
   @override
-  String get layersView_loadRemoteDatabase => 'Load remote database';
+  String get layersView_loadRemoteDatabase => 'Last inn database annensteds fra';
 
   @override
-  String get layersView_loadOnlineSources => 'Load online sources';
+  String get layersView_loadOnlineSources => 'Last inn nettbasert ressurser';
 
   @override
-  String get layersView_loadLocalDatasets => 'Load local datasets';
+  String get layersView_loadLocalDatasets => 'Last inn lokale datasett';
 
   @override
-  String get layersView_loading => 'Loading…';
+  String get layersView_loading => 'Laster inn …';
 
   @override
-  String get layersView_zoomTo => 'Zoom to';
+  String get layersView_zoomTo => 'Forstørr til';
 
   @override
-  String get layersView_properties => 'Properties';
+  String get layersView_properties => 'Egenskaper';
 
   @override
-  String get layersView_delete => 'Delete';
+  String get layersView_delete => 'Slett';
 
   @override
-  String get layersView_projCouldNotBeRecognized => 'The proj could not be recognised. Tap to enter epsg manually.';
+  String get layersView_projCouldNotBeRecognized => 'Kunne ikke gjenkjenne proj. Trykk for å skrive inn epsg manuelt.';
 
   @override
-  String get layersView_projNotSupported => 'The proj is not supported. Tap to solve.';
+  String get layersView_projNotSupported => 'Ustøttet proj. Trykk for å løse.';
 
   @override
-  String get layersView_onlyImageFilesWithWorldDef => 'Only image files with world file definition are supported.';
+  String get layersView_onlyImageFilesWithWorldDef => 'Kun bildefiler med verdensfildefinisjon støttes.';
 
   @override
-  String get layersView_onlyImageFileWithPrjDef => 'Only image files with prj file definition are supported.';
+  String get layersView_onlyImageFileWithPrjDef => 'Kun bildefiler med prj-fildefinisjon støttes.';
 
   @override
-  String get layersView_selectTableToLoad => 'Select table to load.';
+  String get layersView_selectTableToLoad => 'Velg tabell å laste inn.';
 
   @override
-  String get layersView_fileFormatNotSUpported => 'File format not supported.';
+  String get layersView_fileFormatNotSUpported => 'Filformatet støttes ikke.';
 
   @override
-  String get onlineSourcesPage_onlineSourcesCatalog => 'Online Sources Catalog';
+  String get onlineSourcesPage_onlineSourcesCatalog => 'Katalog over nettbaserte kilder';
 
   @override
-  String get onlineSourcesPage_loadingTmsLayers => 'Loading TMS layers…';
+  String get onlineSourcesPage_loadingTmsLayers => 'Laster inn TMS-lag …';
 
   @override
-  String get onlineSourcesPage_loadingWmsLayers => 'Loading WMS layers…';
+  String get onlineSourcesPage_loadingWmsLayers => 'Laster inn WMS-lag …';
 
   @override
-  String get onlineSourcesPage_importFromFile => 'Import from file';
+  String get onlineSourcesPage_importFromFile => 'Importer fra fil';
 
   @override
-  String get onlineSourcesPage_theFile => 'The file';
+  String get onlineSourcesPage_theFile => 'Filen';
 
   @override
-  String get onlineSourcesPage_doesntExist => 'doesn\'t exist';
+  String get onlineSourcesPage_doesntExist => 'finnes ikke';
 
   @override
-  String get onlineSourcesPage_onlineSourcesImported => 'Online sources imported.';
+  String get onlineSourcesPage_onlineSourcesImported => 'Nettbaserte kilder importert.';
 
   @override
-  String get onlineSourcesPage_exportToFile => 'Export to file';
+  String get onlineSourcesPage_exportToFile => 'Eksporter til fil';
 
   @override
-  String get onlineSourcesPage_exportedTo => 'Exported to:';
+  String get onlineSourcesPage_exportedTo => 'Eksportert til:';
 
   @override
-  String get onlineSourcesPage_delete => 'Delete';
+  String get onlineSourcesPage_delete => 'Slett';
 
   @override
-  String get onlineSourcesPage_addToLayers => 'Add to layers';
+  String get onlineSourcesPage_addToLayers => 'Legg til i lag';
 
   @override
-  String get onlineSourcesPage_setNameTmsService => 'Set a name for the TMS service';
+  String get onlineSourcesPage_setNameTmsService => 'Sett et navn for TMS-tjenesten';
 
   @override
-  String get onlineSourcesPage_enterName => 'enter name';
+  String get onlineSourcesPage_enterName => 'skriv inn navn';
 
   @override
-  String get onlineSourcesPage_pleaseEnterValidName => 'Please enter a valid name';
+  String get onlineSourcesPage_pleaseEnterValidName => 'Skriv inn et gyldig navn';
 
   @override
-  String get onlineSourcesPage_insertUrlOfService => 'Insert the URL of the service.';
+  String get onlineSourcesPage_insertUrlOfService => 'Sett inn nettadressen til tjenesten.';
 
   @override
-  String get onlineSourcesPage_placeXyzBetBrackets => 'Place the x, y, z between curly brackets.';
+  String get onlineSourcesPage_placeXyzBetBrackets => 'Plasser x,y,z i klammeparenteser';
 
   @override
-  String get onlineSourcesPage_pleaseEnterValidTmsUrl => 'Please enter a valid TMS URL';
+  String get onlineSourcesPage_pleaseEnterValidTmsUrl => 'Skriv inn en gyldig TMS-nettadresse';
 
   @override
-  String get onlineSourcesPage_enterUrl => 'enter URL';
+  String get onlineSourcesPage_enterUrl => 'skriv inn nettadresse';
 
   @override
-  String get onlineSourcesPage_enterSubDomains => 'enter subdomains';
+  String get onlineSourcesPage_enterSubDomains => 'skriv inn underdomener';
 
   @override
-  String get onlineSourcesPage_addAttribution => 'Add an attribution.';
+  String get onlineSourcesPage_addAttribution => 'Legg til en henvisning.';
 
   @override
-  String get onlineSourcesPage_enterAttribution => 'enter attribution';
+  String get onlineSourcesPage_enterAttribution => 'skriv inn henvisning';
 
   @override
-  String get onlineSourcesPage_setMinMaxZoom => 'Set min and max zoom.';
+  String get onlineSourcesPage_setMinMaxZoom => 'Sett minste og høyeste forstørrelse.';
 
   @override
-  String get onlineSourcesPage_minZoom => 'Min zoom';
+  String get onlineSourcesPage_minZoom => 'Minste forstørrelse';
 
   @override
-  String get onlineSourcesPage_maxZoom => 'Max zoom';
+  String get onlineSourcesPage_maxZoom => 'Høyeste forstørrelse';
 
   @override
-  String get onlineSourcesPage_pleaseCheckYourData => 'Please check your data';
+  String get onlineSourcesPage_pleaseCheckYourData => 'Sjekk dataen din';
 
   @override
-  String get onlineSourcesPage_details => 'Details';
+  String get onlineSourcesPage_details => 'Detaljer';
 
   @override
-  String get onlineSourcesPage_name => 'Name: ';
+  String get onlineSourcesPage_name => 'Navn: ';
 
   @override
-  String get onlineSourcesPage_subDomains => 'Subdomains: ';
+  String get onlineSourcesPage_subDomains => 'Underdomener: ';
 
   @override
-  String get onlineSourcesPage_attribution => 'Attribution: ';
+  String get onlineSourcesPage_attribution => 'Henvisning: ';
 
   @override
-  String get onlineSourcesPage_cancel => 'Cancel';
+  String get onlineSourcesPage_cancel => 'Avbryt';
 
   @override
   String get onlineSourcesPage_ok => 'OK';
 
   @override
-  String get onlineSourcesPage_newTmsOnlineService => 'New TMS Online Service';
+  String get onlineSourcesPage_newTmsOnlineService => 'Ny nettbasert TMS-tjeneste';
 
   @override
-  String get onlineSourcesPage_save => 'Save';
+  String get onlineSourcesPage_save => 'Lagre';
 
   @override
-  String get onlineSourcesPage_theBaseUrlWithQuestionMark => 'The base URL-ending with question mark.';
+  String get onlineSourcesPage_theBaseUrlWithQuestionMark => 'Grunn-nettadresse som slutter med spørsmålstegn';
 
   @override
-  String get onlineSourcesPage_pleaseEnterValidWmsUrl => 'Please enter a valid WMS URL';
+  String get onlineSourcesPage_pleaseEnterValidWmsUrl => 'Skriv inn en gyldig WMS-nettadresse';
 
   @override
-  String get onlineSourcesPage_setWmsLayerName => 'Set WMS layer name';
+  String get onlineSourcesPage_setWmsLayerName => 'Sett WMS-lagnavn';
 
   @override
-  String get onlineSourcesPage_enterLayerToLoad => 'enter layer to load';
+  String get onlineSourcesPage_enterLayerToLoad => 'skriv inn lag å laste inn';
 
   @override
-  String get onlineSourcesPage_pleaseEnterValidLayer => 'Please enter a valid layer';
+  String get onlineSourcesPage_pleaseEnterValidLayer => 'Skriv inn et gyldig lag';
 
   @override
-  String get onlineSourcesPage_setWmsImageFormat => 'Set WMS image format';
+  String get onlineSourcesPage_setWmsImageFormat => 'Sett WMS-bildeformat';
 
   @override
-  String get onlineSourcesPage_addAnAttribution => 'Add an attribution.';
+  String get onlineSourcesPage_addAnAttribution => 'Legg til en henvisning.';
 
   @override
-  String get onlineSourcesPage_layer => 'Layer: ';
+  String get onlineSourcesPage_layer => 'Lag: ';
 
   @override
-  String get onlineSourcesPage_url => 'URL: ';
+  String get onlineSourcesPage_url => 'Nettadresse: ';
 
   @override
   String get onlineSourcesPage_format => 'Format';
 
   @override
-  String get onlineSourcesPage_newWmsOnlineService => 'New WMS Online Service';
+  String get onlineSourcesPage_newWmsOnlineService => 'Ny nettbasert WMS-tjeneste';
 
   @override
-  String get remoteDbPage_remoteDatabases => 'Remote Databases';
+  String get remoteDbPage_remoteDatabases => 'Databaser annensteds hen';
 
   @override
-  String get remoteDbPage_delete => 'Delete';
+  String get remoteDbPage_delete => 'Slett';
 
   @override
-  String get remoteDbPage_areYouSureDeleteDatabase => 'Delete the database configuration?';
+  String get remoteDbPage_areYouSureDeleteDatabase => 'Slett databaseoppsettet?';
 
   @override
-  String get remoteDbPage_edit => 'Edit';
+  String get remoteDbPage_edit => 'Rediger';
 
   @override
-  String get remoteDbPage_table => 'table';
+  String get remoteDbPage_table => 'tabell';
 
   @override
-  String get remoteDbPage_user => 'user';
+  String get remoteDbPage_user => 'bruker';
 
   @override
-  String get remoteDbPage_loadInMap => 'Load in map.';
+  String get remoteDbPage_loadInMap => 'Last inn i kart.';
 
   @override
-  String get remoteDbPage_databaseParameters => 'Database Parameters';
+  String get remoteDbPage_databaseParameters => 'Database-parametre';
 
   @override
-  String get remoteDbPage_cancel => 'Cancel';
+  String get remoteDbPage_cancel => 'Avbryt';
 
   @override
   String get remoteDbPage_ok => 'OK';
 
   @override
-  String get remoteDbPage_theUrlNeedsToBeDefined => 'The URL must be defined (postgis:host:port/databasename)';
+  String get remoteDbPage_theUrlNeedsToBeDefined => 'Nettadressen må defineres (postgis:vert:port/databasenavn)';
 
   @override
-  String get remoteDbPage_theUserNeedsToBeDefined => 'A user must be defined.';
+  String get remoteDbPage_theUserNeedsToBeDefined => 'En bruker må defineres.';
 
   @override
-  String get remoteDbPage_password => 'password';
+  String get remoteDbPage_password => 'passord';
 
   @override
-  String get remoteDbPage_thePasswordNeedsToBeDefined => 'A password must be defined.';
+  String get remoteDbPage_thePasswordNeedsToBeDefined => 'Et passord må defineres.';
 
   @override
-  String get remoteDbPage_loadingTables => 'Loading tables…';
+  String get remoteDbPage_loadingTables => 'Laster inn tabeller …';
 
   @override
-  String get remoteDbPage_theTableNeedsToBeDefined => 'The table name must be defined.';
+  String get remoteDbPage_theTableNeedsToBeDefined => 'Tabellnavnet må defineres.';
 
   @override
-  String get remoteDbPage_unableToConnectToDatabase => 'Unable to connect to the database. Check parameters and network.';
+  String get remoteDbPage_unableToConnectToDatabase => 'Kunne ikke koble til databasen. Sjekk parametre og nettverkstilgang.';
 
   @override
-  String get remoteDbPage_optionalWhereCondition => 'optional \"where\" condition';
+  String get remoteDbPage_optionalWhereCondition => 'valgfritt «hvor»-vilkår';
 
   @override
-  String get geoImage_tiffProperties => 'TIFF Properties';
+  String get geoImage_tiffProperties => 'TIFF-egenskaper';
 
   @override
-  String get geoImage_opacity => 'Opacity';
+  String get geoImage_opacity => 'Dekkevne';
 
   @override
-  String get geoImage_colorToHide => 'Color to hide';
+  String get geoImage_colorToHide => 'Farge å skjule';
 
   @override
-  String get gpx_gpxProperties => 'GPX Properties';
+  String get gpx_gpxProperties => 'GPX-egenskaper';
 
   @override
-  String get gpx_wayPoints => 'Waypoints';
+  String get gpx_wayPoints => 'Veipunkter';
 
   @override
-  String get gpx_color => 'Color';
+  String get gpx_color => 'Farge';
 
   @override
-  String get gpx_size => 'Size';
+  String get gpx_size => 'Størrelse';
 
   @override
-  String get gpx_viewLabelsIfAvailable => 'View labels if available?';
+  String get gpx_viewLabelsIfAvailable => 'Vis etiketter hvis tilgjengelig?';
 
   @override
-  String get gpx_tracksRoutes => 'Tracks/routes';
+  String get gpx_tracksRoutes => 'Spor/ruter';
 
   @override
-  String get gpx_width => 'Width';
+  String get gpx_width => 'Bredde';
 
   @override
-  String get gpx_palette => 'Palette';
+  String get gpx_palette => 'Palett';
 
   @override
-  String get tiles_tileProperties => 'Tile Properties';
+  String get tiles_tileProperties => 'Flisegenskaper';
 
   @override
-  String get tiles_opacity => 'Opacity';
+  String get tiles_opacity => 'Dekkevne';
 
   @override
-  String get tiles_loadGeoPackageAsOverlay => 'Load geopackage tiles as overlay image as opposed to tile layer (best for gdal generated data and different projections).';
+  String get tiles_loadGeoPackageAsOverlay => 'Last inn geopakke-flis som overleggsbilde, til forskjell fra flislag (best for gdat-generert data og forskjellige projeksjoner).';
 
   @override
-  String get tiles_colorToHide => 'Color to hide';
+  String get tiles_colorToHide => 'Farge å skjule';
 
   @override
-  String get wms_wmsProperties => 'WMS Properties';
+  String get wms_wmsProperties => 'WMS-egenskaper';
 
   @override
-  String get wms_opacity => 'Opacity';
+  String get wms_opacity => 'Dekkevne';
 
   @override
-  String get featureAttributesViewer_loadingData => 'Loading data…';
+  String get featureAttributesViewer_loadingData => 'Laster inn data …';
 
   @override
-  String get featureAttributesViewer_setNewValue => 'Set new value';
+  String get featureAttributesViewer_setNewValue => 'Sett ny verdi';
 
   @override
-  String get featureAttributesViewer_field => 'Field';
+  String get featureAttributesViewer_field => 'Felt';
 
   @override
-  String get featureAttributesViewer_value => 'VALUE';
+  String get featureAttributesViewer_value => 'Verdi';
 
   @override
-  String get projectsView_projectsView => 'Projects View';
+  String get projectsView_projectsView => 'Prosjektvisning';
 
   @override
-  String get projectsView_openExistingProject => 'Open an existing project';
+  String get projectsView_openExistingProject => 'Åpne et eksisterende prosjekt';
 
   @override
-  String get projectsView_createNewProject => 'Create a new project';
+  String get projectsView_createNewProject => 'Opprett et nytt prosjekt';
 
   @override
-  String get projectsView_recentProjects => 'Recent projects';
+  String get projectsView_recentProjects => 'Nylige prosjekter';
 
   @override
-  String get projectsView_newProject => 'New Project';
+  String get projectsView_newProject => 'Nytt prosjekt';
 
   @override
-  String get projectsView_enterNameForNewProject => 'Enter a name for the new project or accept the proposed.';
+  String get projectsView_enterNameForNewProject => 'Skriv inn et navn på det nye prosjektet eller godta det som er foreslått.';
 
   @override
-  String get dataLoader_note => 'note';
+  String get dataLoader_note => 'notat';
 
   @override
-  String get dataLoader_Note => 'Note';
+  String get dataLoader_Note => 'Notat';
 
   @override
-  String get dataLoader_hasForm => 'Has Form';
+  String get dataLoader_hasForm => 'Har skjema';
 
   @override
-  String get dataLoader_POI => 'POI';
+  String get dataLoader_POI => 'Interessepunkt';
 
   @override
-  String get dataLoader_savingImageToDB => 'Saving image to database…';
+  String get dataLoader_savingImageToDB => 'Lagrer bilde i database …';
 
   @override
-  String get dataLoader_removeNote => 'Remove Note';
+  String get dataLoader_removeNote => 'Fjern notat';
 
   @override
-  String get dataLoader_areYouSureRemoveNote => 'Remove note?';
+  String get dataLoader_areYouSureRemoveNote => 'Fjern notat?';
 
   @override
-  String get dataLoader_image => 'Image';
+  String get dataLoader_image => 'Bilde';
 
   @override
-  String get dataLoader_longitude => 'Longitude';
+  String get dataLoader_longitude => 'Lengdegrad';
 
   @override
-  String get dataLoader_latitude => 'Latitude';
+  String get dataLoader_latitude => 'Breddegrad';
 
   @override
-  String get dataLoader_altitude => 'Altitude';
+  String get dataLoader_altitude => 'Høyde';
 
   @override
-  String get dataLoader_timestamp => 'Timestamp';
+  String get dataLoader_timestamp => 'Tidsstempel';
 
   @override
-  String get dataLoader_removeImage => 'Remove Image';
+  String get dataLoader_removeImage => 'Fjern bilde';
 
   @override
-  String get dataLoader_areYouSureRemoveImage => 'Remove the image?';
+  String get dataLoader_areYouSureRemoveImage => 'Fjern bildet?';
 
   @override
-  String get images_loadingImage => 'Loading image…';
+  String get images_loadingImage => 'Laster inn bilde …';
 
   @override
-  String get about_loadingInformation => 'Loading info…';
+  String get about_loadingInformation => 'Laster inn info …';
 
   @override
-  String get about_ABOUT => 'About ';
+  String get about_ABOUT => 'Om ';
 
   @override
-  String get about_smartMobileAppForSurveyor => 'Smart Mobile App for Surveyor Happiness';
+  String get about_smartMobileAppForSurveyor => 'Smart mobilprogram for landmålerlykke';
 
   @override
-  String get about_applicationVersion => 'Version';
+  String get about_applicationVersion => 'Programversjon';
 
   @override
-  String get about_license => 'License';
+  String get about_license => 'Lisens';
 
   @override
-  String get about_isAvailableUnderGPL3 => ' is copylefted libre software, licensed GPLv3+.';
+  String get about_isAvailableUnderGPL3 => ' er lisensiert GPLv3+.';
 
   @override
-  String get about_sourceCode => 'Source Code';
+  String get about_sourceCode => 'Kildekode';
 
   @override
-  String get about_tapHereToVisitRepo => 'Tap here to visit the source code repository';
+  String get about_tapHereToVisitRepo => 'Trykk her for å besøke kodelageret';
 
   @override
-  String get about_legalInformation => 'Legal Info';
+  String get about_legalInformation => 'Juridisk info';
 
   @override
-  String get about_copyright2020HydroloGIS => 'Copyright © 2020, HydroloGIS S.r.l. — some rights reserved. Tap to visit.';
+  String get about_copyright2020HydroloGIS => 'Opphavsrett © 2020, HydroloGIS S.r.l. — noen rettigheter reservert. Trykk for å besøke.';
 
   @override
-  String get about_supportedBy => 'Supported by';
+  String get about_supportedBy => 'Støttet av';
 
   @override
-  String get about_partiallySupportedByUniversityTrento => 'Partially supported by the project Steep Stream of the University of Trento.';
+  String get about_partiallySupportedByUniversityTrento => 'Delvis støttet av Steep Steam-prosjektet fra Universitetet i Trento.';
 
   @override
-  String get about_privacyPolicy => 'Privacy Policy';
+  String get about_privacyPolicy => 'Personvernspraksis';
 
   @override
-  String get about_tapHereToSeePrivacyPolicy => 'Tap here to see the privacy policy that covers user and location data.';
+  String get about_tapHereToSeePrivacyPolicy => 'Trykk her for å vise personvernspraksis som omhandler bruker- og posisjonsdata.';
 
   @override
-  String get gpsInfoButton_noGpsInfoAvailable => 'No GPS info available…';
+  String get gpsInfoButton_noGpsInfoAvailable => 'Ingen tilgjengelig GPS-info …';
 
   @override
-  String get gpsInfoButton_timestamp => 'Timestamp';
+  String get gpsInfoButton_timestamp => 'Tidsstempel';
 
   @override
-  String get gpsInfoButton_speed => 'Speed';
+  String get gpsInfoButton_speed => 'Hastighet';
 
   @override
-  String get gpsInfoButton_heading => 'Heading';
+  String get gpsInfoButton_heading => 'Retning';
 
   @override
-  String get gpsInfoButton_accuracy => 'Accuracy';
+  String get gpsInfoButton_accuracy => 'Nøyaktighet';
 
   @override
-  String get gpsInfoButton_altitude => 'Altitude';
+  String get gpsInfoButton_altitude => 'Høyde';
 
   @override
-  String get gpsInfoButton_latitude => 'Latitude';
+  String get gpsInfoButton_latitude => 'Breddegrad';
 
   @override
-  String get gpsInfoButton_copyLatitudeToClipboard => 'Copy latitude to clipboard.';
+  String get gpsInfoButton_copyLatitudeToClipboard => 'Kopier breddegrad til utklippstavlen.';
 
   @override
-  String get gpsInfoButton_longitude => 'Longitude';
+  String get gpsInfoButton_longitude => 'Lengdegrad';
 
   @override
-  String get gpsInfoButton_copyLongitudeToClipboard => 'Copy longitude to clipboard.';
+  String get gpsInfoButton_copyLongitudeToClipboard => 'Kopier breddegrad til utklippstavlen.';
 
   @override
-  String get gpsLogButton_stopLogging => 'Stop Logging?';
+  String get gpsLogButton_stopLogging => 'Stopp loggføring?';
 
   @override
-  String get gpsLogButton_stopLoggingAndCloseLog => 'Stop logging and close the current GPS log?';
+  String get gpsLogButton_stopLoggingAndCloseLog => 'Stopp logging og lukk nåværende GPS-logg?';
 
   @override
-  String get gpsLogButton_newLog => 'New Log';
+  String get gpsLogButton_newLog => 'Ny logg';
 
   @override
-  String get gpsLogButton_enterNameForNewLog => 'Enter a name for the new log';
+  String get gpsLogButton_enterNameForNewLog => 'Skriv inn et navn på den nye loggen';
 
   @override
-  String get gpsLogButton_couldNotStartLogging => 'Could not start logging: ';
+  String get gpsLogButton_couldNotStartLogging => 'Kunne ikke starte loggføring: ';
 
   @override
-  String get imageWidgets_loadingImage => 'Loading image…';
+  String get imageWidgets_loadingImage => 'Laster inn bilde …';
 
   @override
-  String get logList_gpsLogsList => 'GPS Logs list';
+  String get logList_gpsLogsList => 'GPS-loggliste';
 
   @override
-  String get logList_selectAll => 'Select all';
+  String get logList_selectAll => 'Velg alt';
 
   @override
-  String get logList_unSelectAll => 'Unselect all';
+  String get logList_unSelectAll => 'Fravelg alt';
 
   @override
-  String get logList_invertSelection => 'Invert selection';
+  String get logList_invertSelection => 'Inverter utvalg';
 
   @override
-  String get logList_mergeSelected => 'Merge selected';
+  String get logList_mergeSelected => 'Flett valgte';
 
   @override
-  String get logList_loadingLogs => 'Loading logs…';
+  String get logList_loadingLogs => 'Laster inn logger …';
 
   @override
-  String get logList_zoomTo => 'Zoom to';
+  String get logList_zoomTo => 'Forstørr til';
 
   @override
-  String get logList_properties => 'Properties';
+  String get logList_properties => 'Egenskaper';
 
   @override
-  String get logList_profileView => 'Profile View';
+  String get logList_profileView => 'Profilvisning';
 
   @override
-  String get logList_toGPX => 'To GPX';
+  String get logList_toGPX => 'Til GPS';
 
   @override
-  String get logList_gpsSavedInExportFolder => 'GPX saved in export folder.';
+  String get logList_gpsSavedInExportFolder => 'GPX lagret i eksportmappe.';
 
   @override
-  String get logList_errorOccurredExportingLogGPX => 'Could not export log to GPX.';
+  String get logList_errorOccurredExportingLogGPX => 'Kunne ikke ekspoertere logg til GPX.';
 
   @override
-  String get logList_delete => 'Delete';
+  String get logList_delete => 'Slett';
 
   @override
-  String get logList_DELETE => 'Delete';
+  String get logList_DELETE => 'Slett';
 
   @override
-  String get logList_areYouSureDeleteTheLog => 'Delete the log?';
+  String get logList_areYouSureDeleteTheLog => 'Slett loggen?';
 
   @override
-  String get logList_hours => 'hours';
+  String get logList_hours => 'timer';
 
   @override
-  String get logList_hour => 'hour';
+  String get logList_hour => 'time';
 
   @override
   String get logList_minutes => 'min';
 
   @override
-  String get logProperties_gpsLogProperties => 'GPS Log Properties';
+  String get logProperties_gpsLogProperties => 'Egenskaper for GPS-logg';
 
   @override
-  String get logProperties_logName => 'Log Name';
+  String get logProperties_logName => 'Loggnavn';
 
   @override
   String get logProperties_start => 'Start';
 
   @override
-  String get logProperties_end => 'End';
+  String get logProperties_end => 'Slutt';
 
   @override
-  String get logProperties_duration => 'Duration';
+  String get logProperties_duration => 'Varighet';
 
   @override
-  String get logProperties_color => 'Color';
+  String get logProperties_color => 'Farge';
 
   @override
-  String get logProperties_palette => 'Palette';
+  String get logProperties_palette => 'Palett';
 
   @override
-  String get logProperties_width => 'Width';
+  String get logProperties_width => 'Bredde';
 
   @override
-  String get logProperties_distanceAtPosition => 'Distance at position:';
+  String get logProperties_distanceAtPosition => 'Distanse ved posisjon:';
 
   @override
-  String get logProperties_totalDistance => 'Total distance:';
+  String get logProperties_totalDistance => 'Total distanse:';
 
   @override
-  String get logProperties_gpsLogView => 'GPS Log View';
+  String get logProperties_gpsLogView => 'GPS-loggvisning';
 
   @override
-  String get logProperties_disableStats => 'Turn off stats';
+  String get logProperties_disableStats => 'Skru av statistikk';
 
   @override
-  String get logProperties_enableStats => 'Turn on stats';
+  String get logProperties_enableStats => 'Skru på statistikk';
 
   @override
-  String get logProperties_totalDuration => 'Total duration:';
+  String get logProperties_totalDuration => 'Total varighet:';
 
   @override
-  String get logProperties_timestamp => 'Timestamp:';
+  String get logProperties_timestamp => 'Tidsstempel:';
 
   @override
-  String get logProperties_durationAtPosition => 'Duration at position:';
+  String get logProperties_durationAtPosition => 'Varighet ved posisjon:';
 
   @override
-  String get logProperties_speed => 'Speed:';
+  String get logProperties_speed => 'Hastighet:';
 
   @override
-  String get logProperties_elevation => 'Elevation:';
+  String get logProperties_elevation => 'Høyde:';
 
   @override
-  String get noteList_simpleNotesList => 'Simple List of Notes';
+  String get noteList_simpleNotesList => 'Enkel notatliste';
 
   @override
-  String get noteList_formNotesList => 'List of Form Notes';
+  String get noteList_formNotesList => 'Skjemanotatliste';
 
   @override
-  String get noteList_loadingNotes => 'Loading notes…';
+  String get noteList_loadingNotes => 'Laster inn notater …';
 
   @override
-  String get noteList_zoomTo => 'Zoom to';
+  String get noteList_zoomTo => 'Forstørr til';
 
   @override
-  String get noteList_edit => 'Edit';
+  String get noteList_edit => '«Rediger»';
 
   @override
-  String get noteList_properties => 'Properties';
+  String get noteList_properties => 'Egenskaper';
 
   @override
-  String get noteList_delete => 'Delete';
+  String get noteList_delete => 'Slett';
 
   @override
-  String get noteList_DELETE => 'Delete';
+  String get noteList_DELETE => 'Slett';
 
   @override
-  String get noteList_areYouSureDeleteNote => 'Delete the note?';
+  String get noteList_areYouSureDeleteNote => 'Slett notatet?';
 
   @override
-  String get settings_settings => 'Settings';
+  String get settings_settings => 'Innstillinger';
 
   @override
-  String get settings_camera => 'Camera';
+  String get settings_camera => 'Kamera';
 
   @override
-  String get settings_cameraResolution => 'Camera Resolution';
+  String get settings_cameraResolution => 'Kameraoppløsning';
 
   @override
-  String get settings_resolution => 'Resolution';
+  String get settings_resolution => 'Oppløsning';
 
   @override
-  String get settings_theCameraResolution => 'The camera resolution';
+  String get settings_theCameraResolution => 'Kameraoppløsningen';
 
   @override
-  String get settings_screen => 'Screen';
+  String get settings_screen => 'Skjerm';
 
   @override
-  String get settings_screenScaleBarIconSize => 'Screen, Scalebar and Icon Size';
+  String get settings_screenScaleBarIconSize => 'Skjerm, skaleringsfelt og ikonstørrelse';
 
   @override
-  String get settings_keepScreenOn => 'Keep Screen On';
+  String get settings_keepScreenOn => 'Behold skjerm påslått';
 
   @override
-  String get settings_retinaScreenMode => 'HiDPI screen-mode';
+  String get settings_retinaScreenMode => 'HiDPI-skjermmodus';
 
   @override
-  String get settings_toApplySettingEnterExitLayerView => 'Enter and exit the layer view to apply this setting.';
+  String get settings_toApplySettingEnterExitLayerView => 'Åpne og avslutt lagvisningen for å bruke denne innstillingen.';
 
   @override
-  String get settings_colorPickerToUse => 'Color Picker to use';
+  String get settings_colorPickerToUse => 'Fargevelger å bruke';
 
   @override
-  String get settings_mapCenterCross => 'Map Center Cross';
+  String get settings_mapCenterCross => 'Kartsenterkryss';
 
   @override
-  String get settings_color => 'Color';
+  String get settings_color => 'Farge';
 
   @override
-  String get settings_size => 'Size';
+  String get settings_size => 'Størrelse';
 
   @override
-  String get settings_width => 'Width';
+  String get settings_width => 'Bredde';
 
   @override
-  String get settings_mapToolsIconSize => 'Icon Size for Map Tools';
+  String get settings_mapToolsIconSize => 'Ikonstørrelse for kartverktøy';
 
   @override
   String get settings_gps => 'GPS';
 
   @override
-  String get settings_gpsFiltersAndMockLoc => 'GPS filters and mock locations';
+  String get settings_gpsFiltersAndMockLoc => 'GPS-filtre og jukseposisjoner';
 
   @override
-  String get settings_livePreview => 'Live Preview';
+  String get settings_livePreview => 'Sanntidsforhåndsvisning';
 
   @override
-  String get settings_noPointAvailableYet => 'No point available yet.';
+  String get settings_noPointAvailableYet => 'Ingen tilgjengelige punkter enda.';
 
   @override
-  String get settings_longitudeDeg => 'longitude [deg]';
+  String get settings_longitudeDeg => 'lengdegrad [deg]';
 
   @override
-  String get settings_latitudeDeg => 'latitude [deg]';
+  String get settings_latitudeDeg => 'breddegrad [deg]';
 
   @override
-  String get settings_accuracyM => 'accuracy [m]';
+  String get settings_accuracyM => 'nøyaktighet [m]';
 
   @override
-  String get settings_altitudeM => 'altitude [m]';
+  String get settings_altitudeM => 'høyde [m]';
 
   @override
-  String get settings_headingDeg => 'heading [deg]';
+  String get settings_headingDeg => 'retning [deg]';
 
   @override
-  String get settings_speedMS => 'speed [m/s]';
+  String get settings_speedMS => 'hastighet [m/s]';
 
   @override
-  String get settings_isLogging => 'is logging?';
+  String get settings_isLogging => 'loggfører?';
 
   @override
-  String get settings_mockLocations => 'mock locations?';
+  String get settings_mockLocations => 'jukseposisjoner?';
 
   @override
-  String get settings_minDistFilterBlocks => 'Min dist filter blocks';
+  String get settings_minDistFilterBlocks => 'Min. avstand for filterblokker';
 
   @override
-  String get settings_minDistFilterPasses => 'Min dist filter passes';
+  String get settings_minDistFilterPasses => 'Min. avstand for filtreringer';
 
   @override
-  String get settings_minTimeFilterBlocks => 'Min time filter blocks';
+  String get settings_minTimeFilterBlocks => 'Min. tid for filtreringsblokker';
 
   @override
-  String get settings_minTimeFilterPasses => 'Min time filter passes';
+  String get settings_minTimeFilterPasses => 'Min. tid for filtreringer';
 
   @override
-  String get settings_hasBeenBlocked => 'Has been blocked';
+  String get settings_hasBeenBlocked => 'Har blitt blokkert';
 
   @override
-  String get settings_distanceFromPrevM => 'Distance from prev [m]';
+  String get settings_distanceFromPrevM => 'Avstand fra forrige [m]';
 
   @override
-  String get settings_timeFromPrevS => 'Time since prev [s]';
+  String get settings_timeFromPrevS => 'Tid siden forrige [s]';
 
   @override
-  String get settings_locationInfo => 'Location Info';
+  String get settings_locationInfo => 'Posisjonsinfo';
 
   @override
-  String get settings_filters => 'Filters';
+  String get settings_filters => 'Filtre';
 
   @override
-  String get settings_disableFilters => 'Turn off Filters.';
+  String get settings_disableFilters => 'Skru av filtre.';
 
   @override
-  String get settings_enableFilters => 'Turn on Filters.';
+  String get settings_enableFilters => 'Skru på filtre.';
 
   @override
-  String get settings_zoomIn => 'Zoom in';
+  String get settings_zoomIn => 'Forstørr';
 
   @override
-  String get settings_zoomOut => 'Zoom out';
+  String get settings_zoomOut => 'Forminsk';
 
   @override
-  String get settings_activatePointFlow => 'Activate point flow.';
+  String get settings_activatePointFlow => 'Aktiver punktflyt.';
 
   @override
-  String get settings_pausePointsFlow => 'Pause points flow.';
+  String get settings_pausePointsFlow => 'Sett punktflyt på pause.';
 
   @override
-  String get settings_visualizePointCount => 'Visualize point count';
+  String get settings_visualizePointCount => 'Visualiser punktantall';
 
   @override
-  String get settings_showGpsPointsValidPoints => 'Show the GPS points count for VALID points.';
+  String get settings_showGpsPointsValidPoints => 'Vis GPS-punktantall for GYLDIGE punkter.';
 
   @override
-  String get settings_showGpsPointsAllPoints => 'Show the GPS points count for ALL points.';
+  String get settings_showGpsPointsAllPoints => 'Vis GPS-punktantall for ALLE punkter.';
 
   @override
-  String get settings_logFilters => 'Log filters';
+  String get settings_logFilters => 'Logg-filtre';
 
   @override
-  String get settings_minDistanceBetween2Points => 'Min distance between 2 points.';
+  String get settings_minDistanceBetween2Points => 'Minste avstand mellom to punkter.';
 
   @override
-  String get settings_minTimespanBetween2Points => 'Min timespan between 2 points.';
+  String get settings_minTimespanBetween2Points => 'Minste tidsforløp mellom to punkter.';
 
   @override
-  String get settings_gpsFilter => 'GPS Filter';
+  String get settings_gpsFilter => 'GPS-filter';
 
   @override
-  String get settings_disable => 'Turn off';
+  String get settings_disable => 'Skru av';
 
   @override
-  String get settings_enable => 'Turn on';
+  String get settings_enable => 'Skru på';
 
   @override
-  String get settings_theUseOfTheGps => 'the use of filtered GPS.';
+  String get settings_theUseOfTheGps => 'bruk av filtrert GPS.';
 
   @override
-  String get settings_warningThisWillAffectGpsPosition => 'Warning: This will affect GPS position, notes insertion, log statistics and charting.';
+  String get settings_warningThisWillAffectGpsPosition => 'Advarsel: Dette har innvirkning på GPS-posisjon, notatinnsetting, loggføringsstatistikk og diagramplotting.';
 
   @override
-  String get settings_MockLocations => 'Mock locations';
+  String get settings_MockLocations => 'Jukseposisjoner';
 
   @override
-  String get settings_testGpsLogDemoUse => 'test GPS log for demo use.';
+  String get settings_testGpsLogDemoUse => 'test-GPS-logg for demobruk.';
 
   @override
-  String get settings_setDurationGpsPointsInMilli => 'Set duration for GPS points in milliseconds.';
+  String get settings_setDurationGpsPointsInMilli => 'Sett varighet for GPS-punkter i millisekunder.';
 
   @override
-  String get settings_SETTING => 'Setting';
+  String get settings_SETTING => 'Innstilling';
 
   @override
-  String get settings_setMockedGpsDuration => 'Set Mocked GPS duration';
+  String get settings_setMockedGpsDuration => 'Sett varighet for jukse-GPS';
 
   @override
-  String get settings_theValueHasToBeInt => 'The value has to be a whole number.';
+  String get settings_theValueHasToBeInt => 'Verdien må være et heltall.';
 
   @override
-  String get settings_milliseconds => 'milliseconds';
+  String get settings_milliseconds => 'millisekunder';
 
   @override
-  String get settings_useGoogleToImproveLoc => 'Use Google Services to improve location';
+  String get settings_useGoogleToImproveLoc => 'Bruk Google-tjenester for å forbedre posisjon';
 
   @override
-  String get settings_useOfGoogleServicesRestart => 'use of Google services (app restart needed).';
+  String get settings_useOfGoogleServicesRestart => 'bruk av Google-tjenester (programomstart kreves).';
 
   @override
-  String get settings_gpsLogsViewMode => 'GPS Logs view mode';
+  String get settings_gpsLogsViewMode => 'GPS-loggvisningsmodus';
 
   @override
-  String get settings_logViewModeForOrigData => 'Log view mode for original data.';
+  String get settings_logViewModeForOrigData => 'Loggvisningsmodus for opprinnelig data.';
 
   @override
-  String get settings_logViewModeFilteredData => 'Log view mode for filtered data.';
+  String get settings_logViewModeFilteredData => 'Loggvisningsmodus for filtrert data.';
 
   @override
-  String get settings_cancel => 'Cancel';
+  String get settings_cancel => 'Avbryt';
 
   @override
   String get settings_ok => 'OK';
 
   @override
-  String get settings_notesViewModes => 'Notes view modes';
+  String get settings_notesViewModes => 'Notatvisningsmodus';
 
   @override
-  String get settings_selectNotesViewMode => 'Select a mode to view notes in.';
+  String get settings_selectNotesViewMode => 'Velg modus å vise notater i.';
 
   @override
-  String get settings_mapPlugins => 'Map Plugins';
+  String get settings_mapPlugins => 'Kartprogramtillegg';
 
   @override
-  String get settings_vectorLayers => 'Vector Layers';
+  String get settings_vectorLayers => 'Vektorielle lag';
 
   @override
-  String get settings_loadingOptionsInfoTool => 'Loading Options and Info Tool';
+  String get settings_loadingOptionsInfoTool => 'Innlasting av innstillinger og infoverktøy';
 
   @override
-  String get settings_dataLoading => 'Data loading';
+  String get settings_dataLoading => 'Datainnlasting';
 
   @override
-  String get settings_maxNumberFeatures => 'Max number of features.';
+  String get settings_maxNumberFeatures => 'Maksimalt antall funksjoner.';
 
   @override
-  String get settings_maxNumFeaturesPerLayer => 'Max features per layer. Remove and add the layer to apply.';
+  String get settings_maxNumFeaturesPerLayer => 'Maksimalt antall funksjoner å laste inn per lag. Fjern og legg til laget for å bruke.';
 
   @override
-  String get settings_all => 'all';
+  String get settings_all => 'alle';
 
   @override
-  String get settings_loadMapArea => 'Load map area.';
+  String get settings_loadMapArea => 'Last inn kartområde.';
 
   @override
-  String get settings_loadOnlyLastVisibleArea => 'Load only on the last visible map area. Remove and add the layer again to apply.';
+  String get settings_loadOnlyLastVisibleArea => 'Kun last inn på sist synlige kartområde. Fjern og legg til igjen laget for å bruke.';
 
   @override
-  String get settings_infoTool => 'Info Tool';
+  String get settings_infoTool => 'Infoverktøy';
 
   @override
-  String get settings_tapSizeInfoToolPixels => 'Tap size of the info tool in pixels.';
+  String get settings_tapSizeInfoToolPixels => 'Trykkingsstørrelse for infoverktøyet i piksler.';
 
   @override
-  String get settings_editingTool => 'Editing tool';
+  String get settings_editingTool => 'Redigeringsverktøy';
 
   @override
-  String get settings_editingDragIconSize => 'Editing drag handler icon size.';
+  String get settings_editingDragIconSize => 'Rediger ikonstørrelse for dragningshåndterer.';
 
   @override
-  String get settings_editingIntermediateDragIconSize => 'Editing intermediate drag handler icon size.';
+  String get settings_editingIntermediateDragIconSize => 'Redigering av ikonstørrelse for mellomliggende dragningshåndterer.';
 
   @override
-  String get settings_diagnostics => 'Diagnostics';
+  String get settings_diagnostics => 'Diagnostikk';
 
   @override
-  String get settings_diagnosticsDebugLog => 'Diagnostics and Debug Log';
+  String get settings_diagnosticsDebugLog => 'Diagnostikk og avlusningslogg';
 
   @override
-  String get settings_openFullDebugLog => 'Open full debug log';
+  String get settings_openFullDebugLog => 'Åpne full avlusningslogg';
 
   @override
-  String get settings_debugLogView => 'Debug Log View';
+  String get settings_debugLogView => 'Avlusningsloggvisning';
 
   @override
-  String get settings_viewAllMessages => 'View all messages';
+  String get settings_viewAllMessages => 'Vis alle meldinger';
 
   @override
-  String get settings_viewOnlyErrorsWarnings => 'View only errors and warnings';
+  String get settings_viewOnlyErrorsWarnings => 'Vis kun feil og advarsler';
 
   @override
-  String get settings_clearDebugLog => 'Clear debug log';
+  String get settings_clearDebugLog => 'Tøm avlusningslogg';
 
   @override
-  String get settings_loadingData => 'Loading data…';
+  String get settings_loadingData => 'Laster inn data …';
 
   @override
-  String get settings_device => 'Device';
+  String get settings_device => 'Enhet';
 
   @override
-  String get settings_deviceIdentifier => 'Device identifier';
+  String get settings_deviceIdentifier => 'Enhetsidentifikator';
 
   @override
-  String get settings_deviceId => 'Device ID';
+  String get settings_deviceId => 'Enhets-ID';
 
   @override
-  String get settings_overrideDeviceId => 'Override Device ID';
+  String get settings_overrideDeviceId => 'Overstyr enhets-ID';
 
   @override
-  String get settings_overrideId => 'Override ID';
+  String get settings_overrideId => 'Overstyr ID';
 
   @override
-  String get settings_pleaseEnterValidPassword => 'Please enter a valid server password.';
+  String get settings_pleaseEnterValidPassword => 'Skriv inn et gyldig tjenerpassord.';
 
   @override
   String get settings_gss => 'GSS';
 
   @override
-  String get settings_geopaparazziSurveyServer => 'Geopaparazzi Survey Server';
+  String get settings_geopaparazziSurveyServer => 'Geopaparazzi-undersøkelsestjener';
 
   @override
-  String get settings_serverUrl => 'Server URL';
+  String get settings_serverUrl => 'Tjenernettadresse';
 
   @override
-  String get settings_serverUrlStartWithHttp => 'The server URL needs to start with HTTP or HTTPS.';
+  String get settings_serverUrlStartWithHttp => 'Tjenernettadressen må starte med HTTP eller HTTPS.';
 
   @override
-  String get settings_serverPassword => 'Server Password';
+  String get settings_serverPassword => 'Tjenerpassord';
 
   @override
-  String get settings_allowSelfSignedCert => 'Allow self signed certificates';
+  String get settings_allowSelfSignedCert => 'Tillat selvsignerte sertifikater.';
 
   @override
-  String get toolbarTools_zoomOut => 'Zoom out';
+  String get toolbarTools_zoomOut => 'Forminsk';
 
   @override
-  String get toolbarTools_zoomIn => 'Zoom in';
+  String get toolbarTools_zoomIn => 'Forstørr';
 
   @override
-  String get toolbarTools_cancelCurrentEdit => 'Cancel current edit.';
+  String get toolbarTools_cancelCurrentEdit => 'Avbryt pågående redigering.';
 
   @override
-  String get toolbarTools_saveCurrentEdit => 'Save current edit.';
+  String get toolbarTools_saveCurrentEdit => 'Lagre nåværende redigering.';
 
   @override
-  String get toolbarTools_insertPointMapCenter => 'Insert point in map center.';
+  String get toolbarTools_insertPointMapCenter => 'Sett inn punkt i kartsenter.';
 
   @override
-  String get toolbarTools_insertPointGpsPos => 'Insert point in GPS position.';
+  String get toolbarTools_insertPointGpsPos => 'Sett inn punkt på GPS-posisjon.';
 
   @override
-  String get toolbarTools_removeSelectedFeature => 'Remove selected feature.';
+  String get toolbarTools_removeSelectedFeature => 'Fjern valgt funksjon.';
 
   @override
-  String get toolbarTools_showFeatureAttributes => 'Show feature attributes.';
+  String get toolbarTools_showFeatureAttributes => 'Vis funksjonsattributter.';
 
   @override
-  String get toolbarTools_featureDoesNotHavePrimaryKey => 'The feature does not have a primary key. Editing is not allowed.';
+  String get toolbarTools_featureDoesNotHavePrimaryKey => 'Funksjonen har ingen hovednøkkel. Redigering tillates ikke.';
 
   @override
-  String get toolbarTools_queryFeaturesVectorLayers => 'Query features from loaded vector layers.';
+  String get toolbarTools_queryFeaturesVectorLayers => 'Utfør spørring av funksjoner innlastet fra vektorielle lag.';
 
   @override
-  String get toolbarTools_measureDistanceWithFinger => 'Measure distances on the map with your finger.';
+  String get toolbarTools_measureDistanceWithFinger => 'Mål avstander i kartet med fingeren din.';
 
   @override
-  String get toolbarTools_toggleFenceMapCenter => 'Toggle fence in map center.';
+  String get toolbarTools_toggleFenceMapCenter => 'Veksle gjerde i kartsenter.';
 
   @override
-  String get toolbarTools_modifyGeomVectorLayers => 'Modify the geometry of editable vector layers.';
+  String get toolbarTools_modifyGeomVectorLayers => 'Endre geometri for redigerbare vektorielle lag.';
 
   @override
-  String get coachMarks_singleTap => 'Single tap: ';
+  String get coachMarks_singleTap => 'Enkelt trykk: ';
 
   @override
-  String get coachMarks_longTap => 'Long tap: ';
+  String get coachMarks_longTap => 'Lang-trykk: ';
 
   @override
-  String get coachMarks_doubleTap => 'Double tap: ';
+  String get coachMarks_doubleTap => 'Dobbelttrykk: ';
 
   @override
-  String get coachMarks_simpleNoteButton => 'Simple Notes Button';
+  String get coachMarks_simpleNoteButton => 'Knapp for enkle notater';
 
   @override
-  String get coachMarks_addNewNote => 'add a new note';
+  String get coachMarks_addNewNote => 'legg til et nytt notat';
 
   @override
-  String get coachMarks_viewNotesList => 'view list of notes';
+  String get coachMarks_viewNotesList => 'vis notatliste';
 
   @override
-  String get coachMarks_viewNotesSettings => 'view settings for notes';
+  String get coachMarks_viewNotesSettings => 'vis notatinnstillinger';
 
   @override
-  String get coachMarks_formNotesButton => 'Form Notes Button';
+  String get coachMarks_formNotesButton => 'Knapp for skjemanotater';
 
   @override
-  String get coachMarks_addNewFormNote => 'add new form note';
+  String get coachMarks_addNewFormNote => 'legg til nytt skjemanotat';
 
   @override
-  String get coachMarks_viewFormNoteList => 'view list of form notes';
+  String get coachMarks_viewFormNoteList => 'vis liste over skjemanotater';
 
   @override
-  String get coachMarks_gpsLogButton => 'GPS Log Button';
+  String get coachMarks_gpsLogButton => 'GPS-loggingsnkapp';
 
   @override
-  String get coachMarks_startStopLogging => 'start logging/stop logging';
+  String get coachMarks_startStopLogging => 'start logging/stopp logging';
 
   @override
-  String get coachMarks_viewLogsList => 'view list of logs';
+  String get coachMarks_viewLogsList => 'vis loggliste';
 
   @override
-  String get coachMarks_viewLogsSettings => 'view log settings';
+  String get coachMarks_viewLogsSettings => 'vis logginnstillinger';
 
   @override
-  String get coachMarks_gpsInfoButton => 'GPS Info Button (if applicable)';
+  String get coachMarks_gpsInfoButton => 'GPS-infoknapp (hvis relevant)';
 
   @override
-  String get coachMarks_centerMapOnGpsPos => 'center map on GPS position';
+  String get coachMarks_centerMapOnGpsPos => 'sentrer kart på GPS-posisjon';
 
   @override
-  String get coachMarks_showGpsInfo => 'show GPS info';
+  String get coachMarks_showGpsInfo => 'vis GPS-info';
 
   @override
-  String get coachMarks_toggleAutoCenterGps => 'toggle automatic center on GPS';
+  String get coachMarks_toggleAutoCenterGps => 'veksle automatisk sentrering på GPS';
 
   @override
-  String get coachMarks_layersViewButton => 'Layer View Button';
+  String get coachMarks_layersViewButton => 'Lagvisningsknapp';
 
   @override
-  String get coachMarks_openLayersView => 'Open the layers view';
+  String get coachMarks_openLayersView => 'Åpne lagvisningen';
 
   @override
-  String get coachMarks_openLayersPluginDialog => 'Open the layer plugins dialog';
+  String get coachMarks_openLayersPluginDialog => 'Åpne lag-programtilleggsdialogen';
 
   @override
-  String get coachMarks_zoomInButton => 'Zoom-in Button';
+  String get coachMarks_zoomInButton => 'Forstørrelsesknapp';
 
   @override
-  String get coachMarks_zoomImMapOneLevel => 'Zoom in the map by one level';
+  String get coachMarks_zoomImMapOneLevel => 'Forstørr kartet ett nivå';
 
   @override
-  String get coachMarks_zoomOutButton => 'Zoom-out Button';
+  String get coachMarks_zoomOutButton => 'Forminskningsknapp';
 
   @override
-  String get coachMarks_zoomOutMapOneLevel => 'Zoom out the map by one level';
+  String get coachMarks_zoomOutMapOneLevel => 'Forminsk kartet ett nivå';
 
   @override
-  String get coachMarks_bottomToolsButton => 'Bottom Tools Button';
+  String get coachMarks_bottomToolsButton => 'Bunnverktøy-knapp';
 
   @override
-  String get coachMarks_toggleBottomToolsBar => 'Toggle bottom tools bar. ';
+  String get coachMarks_toggleBottomToolsBar => 'Veksle bunnverktøyknappen. ';
 
   @override
-  String get coachMarks_toolsButton => 'Tools Button';
+  String get coachMarks_toolsButton => 'Verktøyknapp';
 
   @override
-  String get coachMarks_openEndDrawerToAccessProject => 'Open the end drawer to access project info and sharing options as well as map plugins, feature tools and extras.';
+  String get coachMarks_openEndDrawerToAccessProject => 'Åpne sluttskuffen for å få tilgang til prosjektinfo og delingsvalg, samt kartprogramtillegg, funksjonsverktøy og ekstrating.';
 
   @override
-  String get coachMarks_interactiveCoackMarksButton => 'Interactive coach-marks button';
+  String get coachMarks_interactiveCoackMarksButton => 'Interaktiv veiledningsmerke-knapp';
 
   @override
-  String get coachMarks_openInteractiveCoachMarks => 'Open the interactice coach marks explaining all the actions of the main map view.';
+  String get coachMarks_openInteractiveCoachMarks => 'Åpne de interaktive veiledningsmerkene som forklarer alle handlinger i hovedkartsvisningen.';
 
   @override
-  String get coachMarks_mainMenuButton => 'Main-menu Button';
+  String get coachMarks_mainMenuButton => 'Hovedmeny-knapp';
 
   @override
-  String get coachMarks_openDrawerToLoadProject => 'Open the drawer to load or create a project, import and export data, sync with servers, access settings and exit the app/turn off the GPS.';
+  String get coachMarks_openDrawerToLoadProject => 'Åpne skuffen for å laste inn eller opprette et prosjekt, importere og ekspoertere data, synkronisere data med tjenere, endre innstillinger, og avslutte programmet/skru av GPS.';
 
   @override
-  String get coachMarks_skip => 'Skip';
+  String get coachMarks_skip => 'Hopp over';
 
   @override
-  String get fence_fenceProperties => 'Fence Properties';
+  String get fence_fenceProperties => 'Gjerdeegenskaper';
 
   @override
-  String get fence_delete => 'Delete';
+  String get fence_delete => 'Slett';
 
   @override
-  String get fence_removeFence => 'Remove fence';
+  String get fence_removeFence => 'Fjern gjerde';
 
   @override
-  String get fence_areYouSureRemoveFence => 'Remove the fence?';
+  String get fence_areYouSureRemoveFence => 'Fjern gjerdet?';
 
   @override
-  String get fence_cancel => 'Cancel';
+  String get fence_cancel => 'Avbryt';
 
   @override
   String get fence_ok => 'OK';
 
   @override
-  String get fence_aNewFence => 'a new fence';
+  String get fence_aNewFence => 'et nytt gjerde';
 
   @override
-  String get fence_label => 'Label';
+  String get fence_label => 'Etikett';
 
   @override
-  String get fence_aNameForFence => 'A name for the fence.';
+  String get fence_aNameForFence => 'Et navn på gjerdet.';
 
   @override
-  String get fence_theNameNeedsToBeDefined => 'The name must be defined.';
+  String get fence_theNameNeedsToBeDefined => 'Navnet må defineres.';
 
   @override
   String get fence_radius => 'Radius';
 
   @override
-  String get fence_theFenceRadiusMeters => 'The fence radius in meters.';
+  String get fence_theFenceRadiusMeters => 'Gjerderadius i meter.';
 
   @override
-  String get fence_radiusNeedsToBePositive => 'The radius must be a positive number in meters.';
+  String get fence_radiusNeedsToBePositive => 'Radiusen må være et positivt tall i meter.';
 
   @override
-  String get fence_onEnter => 'On enter';
+  String get fence_onEnter => 'Ved inngang';
 
   @override
-  String get fence_onExit => 'On exit';
+  String get fence_onExit => 'Ved utgang';
 
   @override
-  String get network_cancelledByUser => 'Cancelled by user.';
+  String get network_cancelledByUser => 'Avbrutt av bruker.';
 
   @override
-  String get network_completed => 'Completed.';
+  String get network_completed => 'Fullført.';
 
   @override
-  String get network_buildingBaseCachePerformance => 'Building base cache for improved performance (might take a while)…';
+  String get network_buildingBaseCachePerformance => 'Bygger grunnhurtiglager for bedre ytelse (kan ta en stund)…';
 
   @override
-  String get network_thisFIleAlreadyBeingDownloaded => 'This file is already being downloaded.';
+  String get network_thisFIleAlreadyBeingDownloaded => 'Filen blir allerede lastet ned.';
 
   @override
-  String get network_download => 'Download';
+  String get network_download => 'Last ned';
 
   @override
-  String get network_downloadFile => 'Download file';
+  String get network_downloadFile => 'Last ned fil';
 
   @override
-  String get network_toTheDeviceTakeTime => 'to the device? This can take a while.';
+  String get network_toTheDeviceTakeTime => 'til enheten? Dette kan ta lang tid.';
 
   @override
-  String get network_availableMaps => 'Available maps';
+  String get network_availableMaps => 'Tilgjengelige kart';
 
   @override
-  String get network_searchMapByName => 'Search map by name';
+  String get network_searchMapByName => 'Søk etter kart ved navn';
 
   @override
-  String get network_uploading => 'Uploading';
+  String get network_uploading => 'Opplasting';
 
   @override
-  String get network_pleaseWait => 'please wait…';
+  String get network_pleaseWait => 'vent …';
 
   @override
-  String get network_permissionOnServerDenied => 'Permission on server denied.';
+  String get network_permissionOnServerDenied => 'Tilgang på tjener avslått.';
 
   @override
-  String get network_couldNotConnectToServer => 'Could not connect to the server. Is it online? Check your address.';
+  String get network_couldNotConnectToServer => 'Kunne ikke koble til tjeneren. Er den på nett? Sjekk adressen din.';
 
   @override
-  String get form_sketch_newSketch => 'New Sketch';
+  String get form_sketch_newSketch => 'Ny skisse';
 
   @override
-  String get form_sketch_undo => 'Undo';
+  String get form_sketch_undo => 'Angre';
 
   @override
-  String get form_sketch_noUndo => 'Nothing to undo';
+  String get form_sketch_noUndo => 'Ingenting å angre';
 
   @override
-  String get form_sketch_clear => 'Clear';
+  String get form_sketch_clear => 'Tøm';
 
   @override
-  String get form_sketch_save => 'Save';
+  String get form_sketch_save => 'Lagre';
 
   @override
-  String get form_sketch_sketcher => 'Sketcher';
+  String get form_sketch_sketcher => 'Skissemaker';
 
   @override
-  String get form_sketch_enableDrawing => 'Turn on drawing';
+  String get form_sketch_enableDrawing => 'Skru på tegning';
 
   @override
-  String get form_sketch_enableEraser => 'Turn on eraser';
+  String get form_sketch_enableEraser => 'Skru på viskelær';
 
   @override
-  String get form_sketch_backColor => 'Background color';
+  String get form_sketch_backColor => 'Bakgrunnsfarge';
 
   @override
-  String get form_sketch_strokeColor => 'Stroke color';
+  String get form_sketch_strokeColor => 'Strøkfarge';
 
   @override
-  String get form_sketch_pickColor => 'Pick color';
+  String get form_sketch_pickColor => 'Velg farge';
 
   @override
-  String get form_smash_cantSaveImageDb => 'Could not save image in database.';
+  String get form_smash_cantSaveImageDb => 'Kunne ikke lagre bilde i databasen.';
 }
 
 /// The translations for Norwegian Bokmål, as used in Norway (`nb_NO`).

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,46 +1,39 @@
 PODS:
-  - catcher (0.0.1):
-    - FlutterMacOS
-  - device_info_plus_macos (0.0.1):
+  - device_info_plus (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - package_info (0.0.1):
-    - FlutterMacOS
   - package_info_plus_macos (0.0.1):
     - FlutterMacOS
-  - path_provider_macos (0.0.1):
+  - path_provider_foundation (0.0.1):
+    - Flutter
     - FlutterMacOS
-  - shared_preferences_macos (0.0.1):
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
     - FlutterMacOS
-  - sqlite3 (3.35.5):
-    - sqlite3/common (= 3.35.5)
-  - sqlite3/common (3.35.5)
-  - sqlite3/fts5 (3.35.5):
+  - sqlite3 (3.41.0):
+    - sqlite3/common (= 3.41.0)
+  - sqlite3/common (3.41.0)
+  - sqlite3/fts5 (3.41.0):
     - sqlite3/common
-  - sqlite3/json1 (3.35.5):
+  - sqlite3/perf-threadsafe (3.41.0):
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.35.5):
-    - sqlite3/common
-  - sqlite3/rtree (3.35.5):
+  - sqlite3/rtree (3.41.0):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - FlutterMacOS
-    - sqlite3 (~> 3.35.4)
+    - sqlite3 (~> 3.41.0)
     - sqlite3/fts5
-    - sqlite3/json1
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
 
 DEPENDENCIES:
-  - catcher (from `Flutter/ephemeral/.symlinks/plugins/catcher/macos`)
-  - device_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus_macos/macos`)
+  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - package_info (from `Flutter/ephemeral/.symlinks/plugins/package_info/macos`)
   - package_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos`)
-  - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
-  - shared_preferences_macos (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/macos`)
   - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
@@ -49,37 +42,31 @@ SPEC REPOS:
     - sqlite3
 
 EXTERNAL SOURCES:
-  catcher:
-    :path: Flutter/ephemeral/.symlinks/plugins/catcher/macos
-  device_info_plus_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus_macos/macos
+  device_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  package_info:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info/macos
   package_info_plus_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos
-  path_provider_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
-  shared_preferences_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/macos
   sqlite3_flutter_libs:
     :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/macos
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  catcher: dc8ecb9a4d3e6e36bd403cd34e13673f7ed7ca70
-  device_info_plus_macos: 1ad388a1ef433505c4038e7dd9605aadd1e2e9c7
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
-  package_info: 6eba2fd8d3371dda2d85c8db6fe97488f24b74b2
+  device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   package_info_plus_macos: f010621b07802a241d96d01876d6705f15e77c1c
-  path_provider_macos: 160cab0d5461f0c0e02995469a98f24bdb9a3f1f
-  shared_preferences_macos: 480ce071d0666e37cef23fe6c702293a3d21799e
-  sqlite3: 75da32fd4e3574f6c38566a9f0114cfe792c8db5
-  sqlite3_flutter_libs: b8781af39b939e25ca76000127ed83312b974f08
-  url_launcher_macos: 45af3d61de06997666568a7149c1be98b41c95d4
+  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
+  shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
+  sqlite3: d31b2b69d59bd1b4ab30e5c92eb18fd8e82fa392
+  sqlite3_flutter_libs: f20746e4a0245afbee4f20d9afc0072ebff7cc26
+  url_launcher_macos: 5335912b679c073563f29d89d33d10d459f95451
 
-PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.3

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -205,7 +205,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -279,6 +279,7 @@
 		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -321,24 +322,20 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/catcher/catcher.framework",
-				"${BUILT_PRODUCTS_DIR}/device_info_plus_macos/device_info_plus_macos.framework",
-				"${BUILT_PRODUCTS_DIR}/package_info/package_info.framework",
+				"${BUILT_PRODUCTS_DIR}/device_info_plus/device_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/package_info_plus_macos/package_info_plus_macos.framework",
-				"${BUILT_PRODUCTS_DIR}/path_provider_macos/path_provider_macos.framework",
-				"${BUILT_PRODUCTS_DIR}/shared_preferences_macos/shared_preferences_macos.framework",
+				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
+				"${BUILT_PRODUCTS_DIR}/shared_preferences_foundation/shared_preferences_foundation.framework",
 				"${BUILT_PRODUCTS_DIR}/sqlite3/sqlite3.framework",
 				"${BUILT_PRODUCTS_DIR}/sqlite3_flutter_libs/sqlite3_flutter_libs.framework",
 				"${BUILT_PRODUCTS_DIR}/url_launcher_macos/url_launcher_macos.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/catcher.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info_plus_macos.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus_macos.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_macos.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_macos.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_foundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqlite3.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqlite3_flutter_libs.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_macos.framework",
@@ -422,7 +419,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -505,7 +502,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -552,7 +549,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,51 +5,58 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "4897882604d919befd350648c7f91926a9d5de99e67b455bf0917cc2362f4bb8"
+      url: "https://pub.dev"
     source: hosted
     version: "47.0.0"
   after_layout:
     dependency: "direct main"
     description:
       name: after_layout
-      url: "https://pub.dartlang.org"
+      sha256: "95a1cb2ca1464f44f14769329fbf15987d20ab6c88f8fc5d359bd362be625f29"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "690e335554a8385bc9d787117d9eb52c0c03ee207a607e593de3c9d71b1cfe80"
+      url: "https://pub.dev"
     source: hosted
     version: "4.7.0"
   animated_stack_widget:
     dependency: transitive
     description:
       name: animated_stack_widget
-      url: "https://pub.dartlang.org"
+      sha256: ce4788dd158768c9d4388354b6fb72600b78e041a37afc4c279c63ecafcb9408
+      url: "https://pub.dev"
     source: hosted
     version: "0.0.4"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: d6347d54a2d8028e0437e3c099f66fdb8ae02c4720c1e7534c9f24c10351f85d
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.6"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   background_locator_2:
     dependency: "direct main"
     description:
@@ -63,210 +70,240 @@ packages:
     dependency: "direct main"
     description:
       name: badges
-      url: "https://pub.dartlang.org"
+      sha256: "461031a60efbb95276f52107f63d5d45008b5ca1eb7f8ca440cadda9ec2143b0"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "3.0.2"
   barcode:
     dependency: transitive
     description:
       name: barcode
-      url: "https://pub.dartlang.org"
+      sha256: "52570564684bbb0240a9f1fdb6bad12adc5e0540103c1c96d6dd550bd928b1c9"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   buffer:
     dependency: transitive
     description:
       name: buffer
-      url: "https://pub.dartlang.org"
+      sha256: "8962c12174f53e2e848a6acd7ac7fd63d8a1a6a316c20c458a832d87eba5422a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dartlang.org"
+      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.5"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.3"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      url: "https://pub.dartlang.org"
+      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.3+4"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   dart_hydrologis_db:
     dependency: "direct main"
     description:
       name: dart_hydrologis_db
-      url: "https://pub.dartlang.org"
+      sha256: "4c4bc5fa5c6f9a78548551f64d6982b8500c74abb8b21da6cbb33bedd54850d6"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1+4"
   dart_hydrologis_utils:
     dependency: "direct main"
     description:
       name: dart_hydrologis_utils
-      url: "https://pub.dartlang.org"
+      sha256: "4b69db902f9189780c82dd47037a907eea0583f449bd5c08c357be73b918069c"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
   dart_jts:
     dependency: "direct main"
     description:
       name: dart_jts
-      url: "https://pub.dartlang.org"
+      sha256: a61d8fd5f48342643291fd895e1e762f5b6149b76efc969b79f5e3c6b2a4730c
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.2+3"
   dart_postgis:
     dependency: "direct main"
     description:
       name: dart_postgis
-      url: "https://pub.dartlang.org"
+      sha256: bf33c13dc8ca244e9ea1c14006286589cbec0097245e7e112dd5797d26800f63
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
   dart_shp:
     dependency: "direct main"
     description:
       name: dart_shp
-      url: "https://pub.dartlang.org"
+      sha256: e1fa1b185b227ad2bba791e04588ff89788ccbfe07f044e8ca7c3d9323f16a4c
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.0"
   device_info_plus:
     dependency: transitive
     description:
       name: device_info_plus
-      url: "https://pub.dartlang.org"
+      sha256: "1d6e5a61674ba3a68fb048a7c7b4ff4bebfed8d7379dbe8f2b718231be9a7c95"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
   dio:
     dependency: transitive
     description:
       name: dio
-      url: "https://pub.dartlang.org"
+      sha256: "7d328c4d898a61efc3cd93655a0955858e29a0aa647f0f9e02d59b3bb275e2e8"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.6"
   ecache:
     dependency: transitive
     description:
       name: ecache
-      url: "https://pub.dartlang.org"
+      sha256: "217d8e6a86cd39df9c65151f840209d37f41b0909c97ad73fe00ef1c8db284e4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   equatable:
     dependency: transitive
     description:
       name: equatable
-      url: "https://pub.dartlang.org"
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   extended_image:
     dependency: "direct main"
     description:
       name: extended_image
-      url: "https://pub.dartlang.org"
+      sha256: a6b738d9b8d5513be72c545cc3e9c5c451fbee77c8db3cbec7c32ae85b82fb93
+      url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
   extended_image_library:
     dependency: transitive
     description:
       name: extended_image_library
-      url: "https://pub.dartlang.org"
+      sha256: b1de389378589e4dffb3564d782373238f19064037458092c49b3043b2791b2b
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   file_picker:
     dependency: transitive
     description:
       name: file_picker
-      url: "https://pub.dartlang.org"
+      sha256: d090ae03df98b0247b82e5928f44d1b959867049d18d73635e2e0bc3f49542b9
+      url: "https://pub.dev"
     source: hosted
     version: "5.2.5"
   fl_chart:
     dependency: "direct main"
     description:
       name: fl_chart
-      url: "https://pub.dartlang.org"
+      sha256: "749b3342ea3e95cbf61a0fec31a62606e837377b8b6d0caa7367a7ef80f38b7d"
+      url: "https://pub.dev"
     source: hosted
     version: "0.55.2"
   flutter:
@@ -278,21 +315,24 @@ packages:
     dependency: transitive
     description:
       name: flutter_colorpicker
-      url: "https://pub.dartlang.org"
+      sha256: "458a6ed8ea480eb16ff892aedb4b7092b2804affd7e046591fb03127e8d8ef8b"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   flutter_geopackage:
     dependency: "direct main"
     description:
       name: flutter_geopackage
-      url: "https://pub.dartlang.org"
+      sha256: "5d7aeef38b2660d1fa281779bd3e70a9216cebffc8da54a3589bd375071332e8"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      url: "https://pub.dartlang.org"
+      sha256: a9de6706cd844668beac27c0aed5910fa0534832b3c2cad61a5fd977fce82a5d
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.0"
   flutter_localizations:
@@ -304,35 +344,40 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_map
-      url: "https://pub.dartlang.org"
+      sha256: "09010e452bcd8c57ade1b936b79643c4fd599f93b00d1696630f0b919b6f374a"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   flutter_map_dragmarker:
     dependency: transitive
     description:
       name: flutter_map_dragmarker
-      url: "https://pub.dartlang.org"
+      sha256: "31f9e6a29c60cbcb707b42c29f52054fc5eb6df7012c70fb7717b34b07cd97d4"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   flutter_map_line_editor:
     dependency: "direct main"
     description:
       name: flutter_map_line_editor
-      url: "https://pub.dartlang.org"
+      sha256: f14838bf2e51049aec5e720946d0440b88ef98365cbfc285f61aa5c5b1a58960
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   flutter_map_marker_cluster:
     dependency: "direct main"
     description:
       name: flutter_map_marker_cluster
-      url: "https://pub.dartlang.org"
+      sha256: "88e51a1c6a8046ae90a8620c71af433a13fca3f8831ac7e356b78453c58bf6db"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.4"
   flutter_map_marker_popup:
     dependency: transitive
     description:
       name: flutter_map_marker_popup
-      url: "https://pub.dartlang.org"
+      sha256: "4c0da4301a7007124f3d6d208928075bcb84268785eae8df93d53e2fe3654456"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   flutter_material_pickers:
@@ -348,42 +393,48 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      url: "https://pub.dartlang.org"
+      sha256: "4bef634684b2c7f3468c77c766c831229af829a0cd2d4ee6c1b99558bd14e5d2"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.8"
   flutter_ringtone_player:
     dependency: "direct main"
     description:
       name: flutter_ringtone_player
-      url: "https://pub.dartlang.org"
+      sha256: "0b036416fda0654da52221989bd1a8ccd2876cea57f61ecc3a4fc272bd738c67"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   flutter_screen_wake:
     dependency: transitive
     description:
       name: flutter_screen_wake
-      url: "https://pub.dartlang.org"
+      sha256: "7c69295d1405a5e7b673f5fe938d116076a4e8620cacdf04e884242622296f65"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   flutter_slidable:
     dependency: "direct main"
     description:
       name: flutter_slidable
-      url: "https://pub.dartlang.org"
+      sha256: "6c68e1fad129b4b807b2218ef4cf7f7f6f61c5ec8861c990dc2278d9d03cb09f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   flutter_svg:
     dependency: transitive
     description:
       name: flutter_svg
-      url: "https://pub.dartlang.org"
+      sha256: "6ff9fa12892ae074092de2fa6a9938fb21dbabfdaa2ff57dc697ff912fc8d4b2"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.6"
   flutter_tags_x:
     dependency: transitive
     description:
       name: flutter_tags_x
-      url: "https://pub.dartlang.org"
+      sha256: b9e5e55ff79ff6b8250008eb3ea498ddd0a03213c441b25275484f601654a412
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   flutter_test:
@@ -400,203 +451,232 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "4f4a162323c86ffc1245765cfe138872b8f069deb42f7dbb36115fa27f31469b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   geocoding:
     dependency: "direct main"
     description:
       name: geocoding
-      url: "https://pub.dartlang.org"
+      sha256: "26218460a902d4249b81e6baf9d55ce400fd1ebe6fc0a7e92b2c12b0b8e1e14e"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   geocoding_platform_interface:
     dependency: transitive
     description:
       name: geocoding_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "8848605d307d844d89937cdb4b8ad7dfa880552078f310fa24d8a460f6dddab4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   geodesy:
     dependency: "direct main"
     description:
       name: geodesy
-      url: "https://pub.dartlang.org"
+      sha256: d9959000de938adf760f946546ccbf9ebdff8f4f6d0b5c54e8b8b1ed350b1028
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.0-nullsafety.0"
   geoimage:
     dependency: "direct main"
     description:
       name: geoimage
-      url: "https://pub.dartlang.org"
+      sha256: "5ae1dcebe30e698a263f921ab573eb16fa984adfacd03daba1eff4ba8f75f408"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   golden_toolkit:
     dependency: transitive
     description:
       name: golden_toolkit
-      url: "https://pub.dartlang.org"
+      sha256: "3a37d474cdb8f4505ff8be9f1bb248a6bf3e80ee22ef3c8c3c4c805fff7fa153"
+      url: "https://pub.dev"
     source: hosted
     version: "0.14.0"
   gpx:
     dependency: "direct main"
     description:
       name: gpx
-      url: "https://pub.dartlang.org"
+      sha256: "2afa90c9faf6687e8013a1d159204b81b95da6d6d931b9832111bf10d3e6c229"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   http:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.5"
   http_client_helper:
     dependency: transitive
     description:
       name: http_client_helper
-      url: "https://pub.dartlang.org"
+      sha256: "1f32359bd07a064ad256d1f84ae5f973f69bc972e7287223fa198abe1d969c28"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   idb_shim:
     dependency: transitive
     description:
       name: idb_shim
-      url: "https://pub.dartlang.org"
+      sha256: "7e2ad3d36a4eb549813d1ef10694c0f1fd5b4713a2021f19569c752e74b54cef"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0+1"
   image:
     dependency: transitive
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "8e9d133755c3e84c73288363e6343157c383a0c6c56fc51afcc5d4d7180306d6"
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.0"
   image_picker:
     dependency: transitive
     description:
       name: image_picker
-      url: "https://pub.dartlang.org"
+      sha256: "22207768556b82d55ec70166824350fee32298732d5efa4d6e756f848f51f66a"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.6+3"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      url: "https://pub.dartlang.org"
+      sha256: "68d067baf7f6e401b1124ee83dd6967e67847314250fd68012aab34a69beb344"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.5+7"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      url: "https://pub.dartlang.org"
+      sha256: "66fc6e3877bbde82c33d122f3588777c3784ac5bd7d1cdd79213ef7aecb85b34"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.11"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
-      url: "https://pub.dartlang.org"
+      sha256: "39aa70b5f1e5e7c94585b9738632d5fdb764a5655e40cd9e7b95fbd2fc50c519"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.6+9"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "1991219d9dbc42a99aff77e663af8ca51ced592cd6685c9485e3458302d3d4f8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.3"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   lat_lon_grid_plugin:
     dependency: "direct main"
     description:
       name: lat_lon_grid_plugin
-      url: "https://pub.dartlang.org"
+      sha256: a76231042fb42e79651a9d82b193cba0e0f809c7309d620e2047cdadf16a2fa4
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
   latlong2:
     dependency: "direct main"
     description:
       name: latlong2
-      url: "https://pub.dartlang.org"
+      sha256: "408993a0e3f46e79ce1f129e4cb0386eef6d48dfa6394939ecacfbd7049154ec"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.1"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   lists:
     dependency: transitive
     description:
       name: lists
-      url: "https://pub.dartlang.org"
+      sha256: "4ca5c19ae4350de036a7e996cdd1ee39c93ac0a2b840f4915459b7d0a7d4ab27"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   map_elevation:
     dependency: "direct main"
     description:
       name: map_elevation
-      url: "https://pub.dartlang.org"
+      sha256: "61dbfe33c9de4cfbf2a87412ccfff11487be0292927fc2583a37657b6cd0cb93"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   mapsforge_flutter:
@@ -612,147 +692,168 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   material_design_icons_flutter:
     dependency: transitive
     description:
       name: material_design_icons_flutter
-      url: "https://pub.dartlang.org"
+      sha256: "8c54c21cf336052193559abc64715e4885d6c9220a6dbdfc561a087266cc5385"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.6996"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mgrs_dart:
     dependency: transitive
     description:
       name: mgrs_dart
-      url: "https://pub.dartlang.org"
+      sha256: fb89ae62f05fa0bb90f70c31fc870bcbcfd516c843fb554452ab3396f78586f7
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   nested:
     dependency: transitive
     description:
       name: nested
-      url: "https://pub.dartlang.org"
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      url: "https://pub.dartlang.org"
+      sha256: f62d7253edc197fe3c88d7c2ddab82d68f555e778d55390ccc3537eca8e8d637
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.3+1"
   package_info_plus_linux:
     dependency: transitive
     description:
       name: package_info_plus_linux
-      url: "https://pub.dartlang.org"
+      sha256: "04b575f44233d30edbb80a94e57cad9107aada334fc02aabb42b6becd13c43fc"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   package_info_plus_macos:
     dependency: transitive
     description:
       name: package_info_plus_macos
-      url: "https://pub.dartlang.org"
+      sha256: a2ad8b4acf4cd479d4a0afa5a74ea3f5b1c7563b77e52cc32b3ee6956d5482a6
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: f7a0c8f1e7e981bc65f8b64137a53fd3c195b18d429fba960babc59a5a1c7ae8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   package_info_plus_web:
     dependency: transitive
     description:
       name: package_info_plus_web
-      url: "https://pub.dartlang.org"
+      sha256: f0829327eb534789e0a16ccac8936a80beed4e2401c4d3a74f3f39094a822d3b
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
   package_info_plus_windows:
     dependency: transitive
     description:
       name: package_info_plus_windows
-      url: "https://pub.dartlang.org"
+      sha256: "79524f11c42dd9078b96d797b3cf79c0a2883a50c4920dc43da8562c115089bc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   painter:
     dependency: "direct main"
     description:
       name: painter
-      url: "https://pub.dartlang.org"
+      sha256: "8919468e313a5d8ded41ee1e6db8dec72dd85359174b7866feef8fbc82c603cc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
       name: path_drawing
-      url: "https://pub.dartlang.org"
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
-      url: "https://pub.dartlang.org"
+      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: "04890b994ee89bfa80bf3080bfec40d5a92c5c7a785ebb02c13084a099d2b6f9"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.13"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: "7623b7d4be0f0f7d9a8b5ee6879fc13e4522d4c875ab86801dee4af32b54b83e"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.23"
   path_provider_ex:
@@ -768,308 +869,352 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      url: "https://pub.dartlang.org"
+      sha256: eec003594f19fe2456ea965ae36b3fc967bc5005f508890aafe31fa75e41d972
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: "525ad5e07622d19447ad740b1ed5070031f7a5437f44355ae915ff56e986429a"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.9"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: "642ddf65fde5404f83267e8459ddb4556316d3ee6d511ed193357e25caa3632d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   pdf:
     dependency: transitive
     description:
       name: pdf
-      url: "https://pub.dartlang.org"
+      sha256: "10659b915e65832b106f6d1d213e09b789cc1f24bf282ee911e49db35b96be4d"
+      url: "https://pub.dev"
     source: hosted
     version: "3.8.4"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
-      url: "https://pub.dartlang.org"
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
   permission_handler:
     dependency: "direct main"
     description:
       name: permission_handler
-      url: "https://pub.dartlang.org"
+      sha256: "33c6a1253d1f95fd06fa74b65b7ba907ae9811f9d5c1d3150e51417d04b8d6a8"
+      url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      url: "https://pub.dartlang.org"
+      sha256: "8028362b40c4a45298f1cbfccd227c8dd6caf0e27088a69f2ba2ab15464159e2"
+      url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      url: "https://pub.dartlang.org"
+      sha256: "9c370ef6a18b1c4b2f7f35944d644a56aa23576f23abee654cf73968de93f163"
+      url: "https://pub.dev"
     source: hosted
     version: "9.0.7"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "68abbc472002b5e6dfce47fe9898c6b7d8328d58b5d2524f75e277c07a97eb84"
+      url: "https://pub.dev"
     source: hosted
     version: "3.9.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      url: "https://pub.dartlang.org"
+      sha256: f67cab14b4328574938ecea2db3475dad7af7ead6afab6338772c5f88963e38b
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.2"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
     source: hosted
     version: "3.6.2"
   polylabel:
     dependency: transitive
     description:
       name: polylabel
-      url: "https://pub.dartlang.org"
+      sha256: "41b9099afb2aa6c1730bdd8a0fab1400d287694ec7615dd8516935fa3144214b"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   positioned_tap_detector_2:
     dependency: "direct main"
     description:
       name: positioned_tap_detector_2
-      url: "https://pub.dartlang.org"
+      sha256: "52e06863ad3e1f82b058fd05054fc8c9caeeb3b47d5cea7a24bd9320746059c1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   postgres:
     dependency: transitive
     description:
       name: postgres
-      url: "https://pub.dartlang.org"
+      sha256: ef3ef88ce207403f5de4aa1c37521eeada89184e9ddb3597d52cb9c4eb7fb367
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.2"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   proj4dart:
     dependency: transitive
     description:
       name: proj4dart
-      url: "https://pub.dartlang.org"
+      sha256: c8a659ac9b6864aa47c171e78d41bbe6f5e1d7bd790a5814249e6b68bc44324e
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   provider:
     dependency: transitive
     description:
       name: provider
-      url: "https://pub.dartlang.org"
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   qr:
     dependency: transitive
     description:
       name: qr
-      url: "https://pub.dartlang.org"
+      sha256: "64957a3930367bf97cc211a5af99551d630f2f4625e38af10edd6b19131b64b3"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   queue:
     dependency: transitive
     description:
       name: queue
-      url: "https://pub.dartlang.org"
+      sha256: "9a41ecadc15db79010108c06eae229a45c56b18db699760f34e8c9ac9b831ff9"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0+2"
   quiver:
     dependency: transitive
     description:
       name: quiver
-      url: "https://pub.dartlang.org"
+      sha256: b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   rainbow_color:
     dependency: "direct main"
     description:
       name: rainbow_color
-      url: "https://pub.dartlang.org"
+      sha256: f207a81ecf6ab9f13f38c8966c8ef81ddadd5e62f0d1d457a4e6c86678f12563
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   rainbow_vis:
     dependency: transitive
     description:
       name: rainbow_vis
-      url: "https://pub.dartlang.org"
+      sha256: "4b4873fdfffc5f6d7519215c913478294d44792b9706d212b626e793a9fec171"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   rxdart:
     dependency: transitive
     description:
       name: rxdart
-      url: "https://pub.dartlang.org"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
   sasl_scram:
     dependency: transitive
     description:
       name: sasl_scram
-      url: "https://pub.dartlang.org"
+      sha256: a47207a436eb650f8fdcf54a2e2587b850dc3caef9973ce01f332b07a6fc9cb9
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.1"
   saslprep:
     dependency: transitive
     description:
       name: saslprep
-      url: "https://pub.dartlang.org"
+      sha256: "79c9e163a82f55da542feaf0f7a59031e74493299c92008b2b404cd88d639bb4"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   sembast:
     dependency: transitive
     description:
       name: sembast
-      url: "https://pub.dartlang.org"
+      sha256: "4997717aa84f0622691815d7e2739988b7f7d3a463302fc878f7d5acfa748e96"
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.0+6"
   share_extend:
     dependency: transitive
     description:
       name: share_extend
-      url: "https://pub.dartlang.org"
+      sha256: "98c26f04abae42b0d2080102a42a2653a867a4bec862be1e921cb0cf7cc00916"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   shared_preferences:
     dependency: transitive
     description:
       name: shared_preferences
-      url: "https://pub.dartlang.org"
+      sha256: ee6257848f822b8481691f20c3e6d2bfee2e9eccb2a3d249907fcfb198c55b41
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.18"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      url: "https://pub.dartlang.org"
+      sha256: a51a4f9375097f94df1c6e0a49c0374440d31ab026b59d58a7e7660675879db4
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.16"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      url: "https://pub.dartlang.org"
+      sha256: "6b84fdf06b32bb336f972d373cd38b63734f3461ba56ac2ba01b56d052796259"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
+      sha256: d7fb71e6e20cd3dfffcc823a28da3539b392e53ed5fc5c2b90b55fdaa8a7e8fa
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "824bfd02713e37603b2bdade0842e47d56e7db32b1dcdd1cae533fb88e2913fc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      url: "https://pub.dartlang.org"
+      sha256: "6737b757e49ba93de2a233df229d0b6a87728cea1684da828cbc718b65dcf9d7"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
+      sha256: bd014168e8484837c39ef21065b78f305810ceabc1d4f90be6e3b392ce81b46d
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   sky_engine:
@@ -1099,252 +1244,288 @@ packages:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      url: "https://pub.dartlang.org"
+      sha256: db6350456720a4088a364bbe02052d43056a5ffbd4816fe9d28310dcfbe0dc05
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      url: "https://pub.dartlang.org"
+      sha256: "02f80aea54a19a36b347dedf6d4181ecd9107f5831ea6139cfd0376a3de197ba"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.13"
   stack_trace:
     dependency: "direct main"
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   synchronized:
     dependency: "direct main"
     description:
       name: synchronized
-      url: "https://pub.dartlang.org"
+      sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: a5fcd2d25eeadbb6589e80198a47d6a464ba3e2049da473943b8af9797900c2d
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.4"
+    version: "1.22.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "0ef9755ec6d746951ba0aabe62f874b707690b5ede0fecc818b138fcc9b14888"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.20"
   tuple:
     dependency: transitive
     description:
       name: tuple
-      url: "https://pub.dartlang.org"
+      sha256: "0ea99cd2f9352b2586583ab2ce6489d1f95a5f6de6fb9492faaf97ae2060f0aa"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   tutorial_coach_mark:
     dependency: "direct main"
     description:
       name: tutorial_coach_mark
-      url: "https://pub.dartlang.org"
+      sha256: "6d1ac1b05a05004b5dc30fe56147b015517b15aa976d0ff0c760375d189f0a12"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.4"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   unicode:
     dependency: transitive
     description:
       name: unicode
-      url: "https://pub.dartlang.org"
+      sha256: "0f69e46593d65245774d4f17125c6084d2c20b4e473a983f6e21b7d7762218f1"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
   unorm_dart:
     dependency: transitive
     description:
       name: unorm_dart
-      url: "https://pub.dartlang.org"
+      sha256: "5b35bff83fce4d76467641438f9e867dc9bcfdb8c1694854f230579d68cd8f4b"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "75f2846facd11168d007529d6cd8fcb2b750186bea046af9711f10b907e1587e"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.10"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      url: "https://pub.dartlang.org"
+      sha256: "1f4d9ebe86f333c15d318f81dcdc08b01d45da44af74552608455ebdc08d9732"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.24"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      url: "https://pub.dartlang.org"
+      sha256: c9cd648d2f7ab56968e049d4e9116f96a85517f1dd806b96a86ea1018a3a82e5
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.1"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      url: "https://pub.dartlang.org"
+      sha256: e29039160ab3730e42f3d811dc2a6d5f2864b90a70fb765ea60144b03307f682
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      url: "https://pub.dartlang.org"
+      sha256: "2dddb3291a57b074dade66b5e07e64401dd2487caefd4e9e2f467138d8c7eb06"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6c9ca697a5ae218ce56cece69d46128169a58aa8653c1b01d26fcd4aad8c4370"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      url: "https://pub.dartlang.org"
+      sha256: "574cfbe2390666003c3a1d129bdc4574aaa6728f0c00a4829a81c316de69dd9b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.15"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      url: "https://pub.dartlang.org"
+      sha256: "97c9067950a0d09cbd93e2e3f0383d1403989362b97102fbf446473a48079a4b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      url: "https://pub.dev"
     source: hosted
     version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
   wkt_parser:
     dependency: transitive
     description:
       name: wkt_parser
-      url: "https://pub.dartlang.org"
+      sha256: "8a555fc60de3116c00aad67891bcab20f81a958e4219cc106e3c037aa3937f13"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   xml:
     dependency: "direct main"
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: ac0e3f4bf00ba2708c33fbabbbe766300e509f8c82dbd4ab6525039813f7e2fb
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -145,9 +145,9 @@ dependencies:
   synchronized: ^3.0.0+3
 
   # Apache 2
-  badges: ^2.0.3
+  badges: ^3.0.2
   # git:
-  #   url: https://github.com/moovida/flutter_badges.git
+  #   url: https://github.com/yako-dev/flutter_badges.git
   # MIT
   tutorial_coach_mark: ^1.0.3
 
@@ -261,10 +261,10 @@ flutter:
   generate: true
 
   assets:
-    - assets/OpenSans-Regular.ttf
-    - assets/OpenSans-Bold.ttf
-    - assets/OpenSans-Italic.ttf
-    - assets/OpenSans-BoldItalic.ttf
+    - assets/fonts/OpenSans-Regular.ttf
+    - assets/fonts/OpenSans-Bold.ttf
+    - assets/fonts/OpenSans-Italic.ttf
+    - assets/fonts/OpenSans-BoldItalic.ttf
     - assets/tags.json
     - assets/emptytile256.png
     - assets/maptools_icon.png


### PR DESCRIPTION
Setup with flutter 3.7.6 stable for macOS and iOS

- macos & ios Podfile.lock delete and recreate (Supports DKImagePickerController update)
- Bump badge to 3.0.2 and use namespace
- added l10n/intl_nb to fixes compile error on iOS
- fixed paths for fonts

